### PR TITLE
Correct AWS_REGION

### DIFF
--- a/examples/consumer/README.md
+++ b/examples/consumer/README.md
@@ -8,7 +8,7 @@ Export the required environment vars for connecting to the Kinesis stream:
 
 ```
 export AWS_ACCESS_KEY=
-export AWS_REGION_NAME=
+export AWS_REGION=
 export AWS_SECRET_KEY=
 ```
 


### PR DESCRIPTION
It seems this environment variable name has been updated to `AWS_REGION` instead of `AWS_REGION_NAME`.

[doc ref](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html)

P.S. I am using your kinesis-consumer with some changes to checkpoint package.