### PR TITLE
Use AWS resource iface, overwrite default dynamodb, more explicit in example about overwrite default AWS resrouce client

### DIFF
--- a/checkpoint/ddb/ddb.go
+++ b/checkpoint/ddb/ddb.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
+	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
 )
 
 // Option is used to override defaults when creating a new Checkpoint
@@ -20,6 +21,13 @@ type Option func(*Checkpoint)
 func WithMaxInterval(maxInterval time.Duration) Option {
 	return func(c *Checkpoint) {
 		c.maxInterval = maxInterval
+	}
+}
+
+// WithDynamoClient sets the dynamoDb client
+func WithDynamoClient(svc dynamodbiface.DynamoDBAPI) Option {
+	return func(c *Checkpoint) {
+		c.client = svc
 	}
 }
 
@@ -58,7 +66,7 @@ func New(appName, tableName string, opts ...Option) (*Checkpoint, error) {
 type Checkpoint struct {
 	tableName   string
 	appName     string
-	client      *dynamodb.DynamoDB
+	client      dynamodbiface.DynamoDBAPI
 	maxInterval time.Duration
 	mu          *sync.Mutex // protects the checkpoints
 	checkpoints map[key]string

--- a/client.go
+++ b/client.go
@@ -7,13 +7,14 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/kinesis"
+	"github.com/aws/aws-sdk-go/service/kinesis/kinesisiface"
 )
 
 // ClientOption is used to override defaults when creating a KinesisClient
 type ClientOption func(*KinesisClient)
 
 // WithKinesis overrides the default Kinesis client
-func WithKinesis(svc *kinesis.Kinesis) ClientOption {
+func WithKinesis(svc kinesisiface.KinesisAPI) ClientOption {
 	return func(kc *KinesisClient) {
 		kc.svc = svc
 	}
@@ -36,7 +37,7 @@ func NewKinesisClient(opts ...ClientOption) *KinesisClient {
 
 // KinesisClient acts as wrapper around Kinesis client
 type KinesisClient struct {
-	svc *kinesis.Kinesis
+	svc kinesisiface.KinesisAPI
 }
 
 // GetShardIDs returns shard ids in a given stream

--- a/examples/consumer/main.go
+++ b/examples/consumer/main.go
@@ -11,6 +11,10 @@ import (
 	"os"
 	"os/signal"
 
+    "github.com/aws/aws-sdk-go/aws"
+    "github.com/aws/aws-sdk-go/aws/session"
+    "github.com/aws/aws-sdk-go/service/kinesis"
+
 	consumer "github.com/harlow/kinesis-consumer"
 	checkpoint "github.com/harlow/kinesis-consumer/checkpoint/ddb"
 )
@@ -46,12 +50,16 @@ func main() {
 		logger  = log.New(os.Stdout, "", log.LstdFlags)
 	)
 
+    myKinesisClient := kinesis.New(session.New(aws.NewConfig()))
+    newKclient := consumer.NewKinesisClient(consumer.WithKinesis(myKinesisClient))
+
 	// consumer
 	c, err := consumer.New(
 		*stream,
 		consumer.WithCheckpoint(ck),
 		consumer.WithLogger(logger),
 		consumer.WithCounter(counter),
+        consumer.WithClient(newKclient),
 	)
 	if err != nil {
 		log.Fatalf("consumer error: %v", err)

--- a/examples/consumer/main.go
+++ b/examples/consumer/main.go
@@ -11,9 +11,10 @@ import (
 	"os"
 	"os/signal"
 
-    "github.com/aws/aws-sdk-go/aws"
-    "github.com/aws/aws-sdk-go/aws/session"
-    "github.com/aws/aws-sdk-go/service/kinesis"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/aws/aws-sdk-go/service/kinesis"
 
 	consumer "github.com/harlow/kinesis-consumer"
 	checkpoint "github.com/harlow/kinesis-consumer/checkpoint/ddb"
@@ -39,8 +40,11 @@ func main() {
 	)
 	flag.Parse()
 
+	// Following will overwrite the default dynamodb client
+	myDynamoDbClient := dynamodb.New(session.New(aws.NewConfig()))
+
 	// ddb checkpoint
-	ck, err := checkpoint.New(*app, *table)
+	ck, err := checkpoint.New(*app, *table, checkpoint.WithDynamoClient(myDynamoDbClient))
 	if err != nil {
 		log.Fatalf("checkpoint error: %v", err)
 	}
@@ -50,8 +54,9 @@ func main() {
 		logger  = log.New(os.Stdout, "", log.LstdFlags)
 	)
 
-    myKinesisClient := kinesis.New(session.New(aws.NewConfig()))
-    newKclient := consumer.NewKinesisClient(consumer.WithKinesis(myKinesisClient))
+	// The following 2 lines will overwrite the default kinesis client
+	myKinesisClient := kinesis.New(session.New(aws.NewConfig()))
+	newKclient := consumer.NewKinesisClient(consumer.WithKinesis(myKinesisClient))
 
 	// consumer
 	c, err := consumer.New(
@@ -59,7 +64,7 @@ func main() {
 		consumer.WithCheckpoint(ck),
 		consumer.WithLogger(logger),
 		consumer.WithCounter(counter),
-        consumer.WithClient(newKclient),
+		consumer.WithClient(newKclient),
 	)
 	if err != nil {
 		log.Fatalf("consumer error: %v", err)


### PR DESCRIPTION
* Use AWS resource iface, 
* overwrite default dynamodb (checkpoint ddb)
* more explicit in example about overwrite default AWS resource client (too many people ask that question and end up mugging with constructor in their own fork)