### PR TITLE
Make what aws error to trigger retry decided by caller

### DIFF
--- a/checkpoint/ddb/ddb.go
+++ b/checkpoint/ddb/ddb.go
@@ -127,18 +127,6 @@ func (c *Checkpoint) Set(streamName, shardID, sequenceNumber string) error {
 	return nil
 }
 
-// ValidaCheckpoint validate the checkpoint table exits, shut down
-func (c *Checkpoint) ValidateCheckpoint() error {
-	// ping table to verify it exists
-	_, err := c.client.DescribeTable(&dynamodb.DescribeTableInput{
-		TableName: aws.String(c.tableName),
-	})
-	if err != nil {
-		c.done <- struct{}{}
-	}
-	return err
-}
-
 // Shutdown the checkpoint. Save any in-flight data.
 func (c *Checkpoint) Shutdown() error {
 	c.done <- struct{}{}

--- a/checkpoint/ddb/retryer.go
+++ b/checkpoint/ddb/retryer.go
@@ -1,0 +1,24 @@
+package ddb
+
+import (
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+)
+
+// Retryer interface contains one method that decides whether to retry based on error
+type Retryer interface {
+	ShouldRetry(error) bool
+}
+
+type DefaultRetryer struct {
+	Retryer
+}
+
+func (r *DefaultRetryer) ShouldRetry(err error) bool {
+	if awsErr, ok := err.(awserr.Error); ok {
+		if awsErr.Code() == dynamodb.ErrCodeProvisionedThroughputExceededException {
+			return true
+		}
+	}
+	return false
+}

--- a/examples/consumer/main.go
+++ b/examples/consumer/main.go
@@ -52,10 +52,6 @@ func main() {
 	if err != nil {
 		log.Fatalf("checkpoint error: %v", err)
 	}
-	err = ck.ValidateCheckpoint()
-	if err != nil {
-		log.Fatalf("checkpoint validation error: %v", err)
-	}
 	var (
 		counter = expvar.NewMap("counters")
 		logger  = log.New(os.Stdout, "", log.LstdFlags)


### PR DESCRIPTION
* there are other errors that may warrant retry to stop or user wants to put some custom logic like wait 
* we should let user decide that so let Checkpoint to expose retryer as configurable