### PR TITLE
 Introduce ScanFunc signature and  remove ScanStatus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project will be documented in this file.
 
 Major changes:
 
+* Remove the concept of `ScanStatus` to simplify the scanning interface
+
+For more context on this change see: https://github.com/harlow/kinesis-consumer/issues/75
+
+## v0.3.0 - 2018-12-28
+
+Major changes:
+
 * Remove concept of `Client` it was confusing as it wasn't a direct standin for a Kinesis client.
 * Rename `ScanError` to `ScanStatus` as it's not always an error.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Golang Kinesis Consumer
 
-[![Build Status](https://travis-ci.com/harlow/kinesis-consumer.svg?branch=master)](https://travis-ci.com/harlow/kinesis-consumer) [![GoDoc](https://godoc.org/github.com/harlow/kinesis-consumer?status.svg)](https://godoc.org/github.com/harlow/kinesis-consumers)
+[![Build Status](https://travis-ci.com/harlow/kinesis-consumer.svg?branch=master)](https://travis-ci.com/harlow/kinesis-consumer) [![GoDoc](https://godoc.org/github.com/harlow/kinesis-consumer?status.svg)](https://godoc.org/github.com/harlow/kinesis-consumer)
 
 Kinesis consumer applications written in Go. This library is intended to be a lightweight wrapper around the Kinesis API to read records, save checkpoints (with swappable backends), and gracefully recover from service timeouts/errors.
 

--- a/consumer.go
+++ b/consumer.go
@@ -225,9 +225,9 @@ func (c *Consumer) getShardIterator(streamName, shardID, seqNum string) (*string
 		StreamName: aws.String(streamName),
 	}
 
-	if lastSeqNum != "" {
+	if seqNum != "" {
 		params.ShardIteratorType = aws.String(kinesis.ShardIteratorTypeAfterSequenceNumber)
-		params.StartingSequenceNumber = aws.String(lastSeqNum)
+		params.StartingSequenceNumber = aws.String(seqNum)
 	} else {
 		params.ShardIteratorType = aws.String(c.initialShardIteratorType)
 	}

--- a/consumer.go
+++ b/consumer.go
@@ -139,7 +139,6 @@ func (c *Consumer) ScanShard(ctx context.Context, shardID string, fn ScanFunc) e
 
 	c.logger.Log("scanning", shardID, lastSeqNum)
 
-	// loop until
 	for {
 		select {
 		case <-ctx.Done():
@@ -159,14 +158,13 @@ func (c *Consumer) ScanShard(ctx context.Context, shardID string, fn ScanFunc) e
 				continue
 			}
 
-			// callback func with each record
+			// loop over records, call callback func
 			for _, r := range resp.Records {
 				select {
 				case <-ctx.Done():
 					return nil
 				default:
 					err := fn(r)
-
 					if err != nil && err != SkipCheckpoint {
 						return err
 					}

--- a/consumer.go
+++ b/consumer.go
@@ -198,6 +198,7 @@ func (c *Consumer) getShardIDs(streamName string) ([]string, error) {
 	var listShardsInput = &kinesis.ListShardsInput{
 		StreamName: aws.String(streamName),
 	}
+
 	for {
 		resp, err := c.client.ListShards(listShardsInput)
 		if err != nil {
@@ -216,7 +217,6 @@ func (c *Consumer) getShardIDs(streamName string) ([]string, error) {
 			NextToken: resp.NextToken,
 		}
 	}
-	return ss, nil
 }
 
 func (c *Consumer) getShardIterator(streamName, shardID, seqNum string) (*string, error) {

--- a/examples/consumer/cp-dynamo/main.go
+++ b/examples/consumer/cp-dynamo/main.go
@@ -54,7 +54,7 @@ func main() {
 	}
 
 	var (
-		app    = flag.String("app", "", "App name")
+		app    = flag.String("app", "", "Consumer app name")
 		stream = flag.String("stream", "", "Stream name")
 		table  = flag.String("table", "", "Checkpoint table name")
 	)
@@ -103,11 +103,9 @@ func main() {
 	}()
 
 	// scan stream
-	err = c.Scan(ctx, func(r *consumer.Record) consumer.ScanStatus {
+	err = c.Scan(ctx, func(r *consumer.Record) error {
 		fmt.Println(string(r.Data))
-
-		// continue scanning
-		return consumer.ScanStatus{}
+		return nil // continue scanning
 	})
 	if err != nil {
 		log.Log("scan error: %v", err)

--- a/examples/consumer/cp-postgres/main.go
+++ b/examples/consumer/cp-postgres/main.go
@@ -15,7 +15,7 @@ import (
 
 func main() {
 	var (
-		app     = flag.String("app", "", "App name")
+		app     = flag.String("app", "", "Consumer app name")
 		stream  = flag.String("stream", "", "Stream name")
 		table   = flag.String("table", "", "Table name")
 		connStr = flag.String("connection", "", "Connection Str")
@@ -53,11 +53,9 @@ func main() {
 	}()
 
 	// scan stream
-	err = c.Scan(ctx, func(r *consumer.Record) consumer.ScanStatus {
+	err = c.Scan(ctx, func(r *consumer.Record) error {
 		fmt.Println(string(r.Data))
-
-		// continue scanning
-		return consumer.ScanStatus{}
+		return nil // continue scanning
 	})
 
 	if err != nil {

--- a/examples/consumer/cp-redis/main.go
+++ b/examples/consumer/cp-redis/main.go
@@ -14,7 +14,7 @@ import (
 
 func main() {
 	var (
-		app    = flag.String("app", "", "App name")
+		app    = flag.String("app", "", "Consumer app name")
 		stream = flag.String("stream", "", "Stream name")
 	)
 	flag.Parse()
@@ -46,11 +46,9 @@ func main() {
 	}()
 
 	// scan stream
-	err = c.Scan(ctx, func(r *consumer.Record) consumer.ScanStatus {
+	err = c.Scan(ctx, func(r *consumer.Record) error {
 		fmt.Println(string(r.Data))
-
-		// continue scanning
-		return consumer.ScanStatus{}
+		return nil // continue scanning
 	})
 	if err != nil {
 		log.Fatalf("scan error: %v", err)

--- a/examples/producer/main.go
+++ b/examples/producer/main.go
@@ -25,7 +25,12 @@ func main() {
 	defer f.Close()
 
 	var records []*kinesis.PutRecordsRequestEntry
-	var client = kinesis.New(session.New())
+
+	sess, err := session.NewSession(aws.NewConfig())
+	if err != nil {
+		log.Fatal(err)
+	}
+	var client = kinesis.New(sess)
 
 	// loop over file data
 	b := bufio.NewScanner(f)

--- a/options.go
+++ b/options.go
@@ -1,0 +1,41 @@
+package consumer
+
+import "github.com/aws/aws-sdk-go/service/kinesis/kinesisiface"
+
+// Option is used to override defaults when creating a new Consumer
+type Option func(*Consumer)
+
+// WithCheckpoint overrides the default checkpoint
+func WithCheckpoint(checkpoint Checkpoint) Option {
+	return func(c *Consumer) {
+		c.checkpoint = checkpoint
+	}
+}
+
+// WithLogger overrides the default logger
+func WithLogger(logger Logger) Option {
+	return func(c *Consumer) {
+		c.logger = logger
+	}
+}
+
+// WithCounter overrides the default counter
+func WithCounter(counter Counter) Option {
+	return func(c *Consumer) {
+		c.counter = counter
+	}
+}
+
+// WithClient overrides the default client
+func WithClient(client kinesisiface.KinesisAPI) Option {
+	return func(c *Consumer) {
+		c.client = client
+	}
+}
+
+// ShardIteratorType overrides the starting point for the consumer
+func WithShardIteratorType(t string) Option {
+	return func(c *Consumer) {
+		c.initialShardIteratorType = t
+	}
+}


### PR DESCRIPTION
Major changes:

```go
type ScanFunc func(r *Record) error
```

* Simplify the callback func signature by removing `ScanStatus` 
* Leverage context for cancellation 
* Add custom error `SkipCheckpoint` for special cases when we don't want to checkpoint

Minor changes:

* Use kinesis package constants for shard iterator types
* Move optional config to new file

See conversation on #75 for more details

