### PR TITLE
Fix getShardID does not return more than 100 shards

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -72,7 +72,7 @@ func New(streamName string, opts ...Option) (*Consumer, error) {
 	// new consumer with no-op checkpoint, counter, and logger
 	c := &Consumer{
 		streamName:               streamName,
-		initialShardIteratorType: "TRIM_HORIZON",
+		initialShardIteratorType: kinesis.ShardIteratorTypeTrimHorizon,
 		checkpoint:               &noopCheckpoint{},
 		counter:                  &noopCounter{},
 		logger: &noopLogger{
@@ -280,7 +280,7 @@ func (c *Consumer) getShardIterator(streamName, shardID, lastSeqNum string) (*st
 	}
 
 	if lastSeqNum != "" {
-		params.ShardIteratorType = aws.String("AFTER_SEQUENCE_NUMBER")
+		params.ShardIteratorType = aws.String(kinesis.ShardIteratorTypeAfterSequenceNumber)
 		params.StartingSequenceNumber = aws.String(lastSeqNum)
 	} else {
 		params.ShardIteratorType = aws.String(c.initialShardIteratorType)

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -46,7 +46,7 @@ func TestConsumer_Scan(t *testing.T) {
 					Shards: []*kinesis.Shard{
 						{ShardId: aws.String("myShard")},
 					},
-				},
+					HasMoreShards: aws.Bool(false)},
 			}, nil
 		},
 	}

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -40,13 +40,11 @@ func TestConsumer_Scan(t *testing.T) {
 				Records:           records,
 			}, nil
 		},
-		describeStreamMock: func(input *kinesis.DescribeStreamInput) (*kinesis.DescribeStreamOutput, error) {
-			return &kinesis.DescribeStreamOutput{
-				StreamDescription: &kinesis.StreamDescription{
-					Shards: []*kinesis.Shard{
-						{ShardId: aws.String("myShard")},
-					},
-					HasMoreShards: aws.Bool(false)},
+		listShardsMock: func(input *kinesis.ListShardsInput) (*kinesis.ListShardsOutput, error) {
+			return &kinesis.ListShardsOutput{
+				Shards: []*kinesis.Shard{
+					{ShardId: aws.String("myShard")},
+				},
 			}, nil
 		},
 	}
@@ -94,11 +92,9 @@ func TestConsumer_Scan(t *testing.T) {
 
 func TestConsumer_Scan_NoShardsAvailable(t *testing.T) {
 	client := &kinesisClientMock{
-		describeStreamMock: func(input *kinesis.DescribeStreamInput) (*kinesis.DescribeStreamOutput, error) {
-			return &kinesis.DescribeStreamOutput{
-				StreamDescription: &kinesis.StreamDescription{
-					Shards: make([]*kinesis.Shard, 0),
-				},
+		listShardsMock: func(input *kinesis.ListShardsInput) (*kinesis.ListShardsOutput, error) {
+			return &kinesis.ListShardsOutput{
+				Shards: make([]*kinesis.Shard, 0),
 			}, nil
 		},
 	}
@@ -287,7 +283,11 @@ type kinesisClientMock struct {
 	kinesisiface.KinesisAPI
 	getShardIteratorMock func(*kinesis.GetShardIteratorInput) (*kinesis.GetShardIteratorOutput, error)
 	getRecordsMock       func(*kinesis.GetRecordsInput) (*kinesis.GetRecordsOutput, error)
-	describeStreamMock   func(*kinesis.DescribeStreamInput) (*kinesis.DescribeStreamOutput, error)
+	listShardsMock       func(*kinesis.ListShardsInput) (*kinesis.ListShardsOutput, error)
+}
+
+func (c *kinesisClientMock) ListShards(in *kinesis.ListShardsInput) (*kinesis.ListShardsOutput, error) {
+	return c.listShardsMock(in)
 }
 
 func (c *kinesisClientMock) GetRecords(in *kinesis.GetRecordsInput) (*kinesis.GetRecordsOutput, error) {
@@ -296,10 +296,6 @@ func (c *kinesisClientMock) GetRecords(in *kinesis.GetRecordsInput) (*kinesis.Ge
 
 func (c *kinesisClientMock) GetShardIterator(in *kinesis.GetShardIteratorInput) (*kinesis.GetShardIteratorOutput, error) {
 	return c.getShardIteratorMock(in)
-}
-
-func (c *kinesisClientMock) DescribeStream(in *kinesis.DescribeStreamInput) (*kinesis.DescribeStreamOutput, error) {
-	return c.describeStreamMock(in)
 }
 
 // implementation of checkpoint


### PR DESCRIPTION
Revision 1:
Changes:
1. Now using ListShards API instead of DescribeStream since it gets up to 1000 shards per call.
Testing:
1. Unit Tests modified to include ListShards.
End --

Changes:
1. Get shardId now iterates over the responses from "DescribeStream" to create an array of shardIds till we reach a point where "HasMoreShards" is false.
2. Replaced the string literals "TRIM_HORIZON" and "AFTER_SEQUENCE_NUMBER" with constants present in kinesis library.

Testing:
1. Tested by fetching shards from a stream having more than 100 shards.
2. Unit Test Cases pass.
resolve #80 