### PR TITLE
Use shard broker to monitor and process new shards

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,8 +255,8 @@ The package defaults to `ioutil.Discard` so swallow all logs. This can be custom
 
 ```go
 // logger
-log := &myLogger{
-	logger: log.New(os.Stdout, "consumer-example: ", log.LstdFlags)
+logger := &myLogger{
+	logger: log.New(os.Stdout, "consumer-example: ", log.LstdFlags),
 }
 
 // consumer

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ Get the package source:
 
 The consumer leverages a handler func that accepts a Kinesis record. The `Scan` method will consume all shards concurrently and call the callback func as it receives records from the stream.
 
-_Important: The default Log, Counter, and Checkpoint are no-op which means no logs, counts, or checkpoints will be emitted when scanning the stream. See the options below to override these defaults._
+_Important 1: The `Scan` func will also poll the stream to check for new shards, it will automatcially start consuming new shards added to the stream._
+
+_Important 2: The default Log, Counter, and Checkpoint are no-op which means no logs, counts, or checkpoints will be emitted when scanning the stream. See the options below to override these defaults._
 
 ```go
 import(

--- a/broker.go
+++ b/broker.go
@@ -1,0 +1,102 @@
+package consumer
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/kinesis"
+	"github.com/aws/aws-sdk-go/service/kinesis/kinesisiface"
+)
+
+func newBroker(
+	client kinesisiface.KinesisAPI,
+	streamName string,
+	shardc chan *kinesis.Shard,
+) *broker {
+	return &broker{
+		client:     client,
+		shards:     make(map[string]*kinesis.Shard),
+		streamName: streamName,
+		shardc:     shardc,
+	}
+}
+
+type broker struct {
+	client     kinesisiface.KinesisAPI
+	streamName string
+	shardc     chan *kinesis.Shard
+
+	shardMu sync.Mutex
+	shards  map[string]*kinesis.Shard
+}
+
+func (b *broker) shardLoop(ctx context.Context) {
+	b.fetchShards()
+
+	// add ticker, and cancellation
+	// also add signal to re-pull?
+
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(30 * time.Second):
+				b.fetchShards()
+			}
+		}
+	}()
+}
+
+func (b *broker) fetchShards() {
+	shards, err := b.listShards()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	for _, shard := range shards {
+		if b.takeLease(shard) {
+			b.shardc <- shard
+		}
+	}
+}
+
+func (b *broker) listShards() ([]*kinesis.Shard, error) {
+	var ss []*kinesis.Shard
+	var listShardsInput = &kinesis.ListShardsInput{
+		StreamName: aws.String(b.streamName),
+	}
+
+	for {
+		resp, err := b.client.ListShards(listShardsInput)
+		if err != nil {
+			return nil, fmt.Errorf("ListShards error: %v", err)
+		}
+		ss = append(ss, resp.Shards...)
+
+		if resp.NextToken == nil {
+			return ss, nil
+		}
+
+		listShardsInput = &kinesis.ListShardsInput{
+			NextToken:  resp.NextToken,
+			StreamName: aws.String(b.streamName),
+		}
+	}
+}
+
+func (b *broker) takeLease(shard *kinesis.Shard) bool {
+	b.shardMu.Lock()
+	defer b.shardMu.Unlock()
+
+	if _, ok := b.shards[*shard.ShardId]; ok {
+		return false
+	}
+
+	b.shards[*shard.ShardId] = shard
+	return true
+}

--- a/broker.go
+++ b/broker.go
@@ -49,8 +49,8 @@ func (b *broker) pollShards(ctx context.Context) {
 }
 
 // leaseShards attempts to find new shards that need to be
-// processed; when a new shard is found it passing the shard
-// ID back to the consumer on the shard channel
+// processed; when a new shard is found it passes the shard
+// ID back to the consumer on the shardc channel
 func (b *broker) leaseShards() {
 	b.shardMu.Lock()
 	defer b.shardMu.Unlock()

--- a/broker.go
+++ b/broker.go
@@ -33,11 +33,10 @@ type broker struct {
 	shards  map[string]*kinesis.Shard
 }
 
-func (b *broker) shardLoop(ctx context.Context) {
+func (b *broker) pollShards(ctx context.Context) {
 	b.fetchShards()
 
-	// add ticker, and cancellation
-	// also add signal to re-pull?
+	// TODO: also add signal to re-poll
 
 	go func() {
 		for {

--- a/consumer.go
+++ b/consumer.go
@@ -88,7 +88,7 @@ func (c *Consumer) Scan(ctx context.Context, fn ScanFunc) error {
 	defer cancel()
 
 	go func() {
-		broker.shardLoop(ctx)
+		broker.pollShards(ctx)
 
 		<-ctx.Done()
 		close(shardc)

--- a/consumer.go
+++ b/consumer.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
-	"sync"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -70,7 +69,7 @@ type Consumer struct {
 // function returns the special value SkipCheckpoint.
 type ScanFunc func(*Record) error
 
-// SkipCheckpoint is used as a return value from ScanFuncs to indicate that
+// SkipCheckpoint is used as a return value from ScanFunc to indicate that
 // the current checkpoint should be skipped skipped. It is not returned
 // as an error by any function.
 var SkipCheckpoint = errors.New("skip checkpoint")
@@ -79,51 +78,45 @@ var SkipCheckpoint = errors.New("skip checkpoint")
 // is passed through to each of the goroutines and called with each message pulled from
 // the stream.
 func (c *Consumer) Scan(ctx context.Context, fn ScanFunc) error {
+	var (
+		errc   = make(chan error, 1)
+		shardc = make(chan *kinesis.Shard, 1)
+		broker = newBroker(c.client, c.streamName, shardc)
+	)
+
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	// get shard ids
-	shardIDs, err := c.getShardIDs(c.streamName)
-	if err != nil {
-		return fmt.Errorf("get shards error: %v", err)
-	}
+	go func() {
+		broker.shardLoop(ctx)
 
-	if len(shardIDs) == 0 {
-		return fmt.Errorf("no shards available")
-	}
+		<-ctx.Done()
+		close(shardc)
+	}()
 
-	var (
-		wg   sync.WaitGroup
-		errc = make(chan error, 1)
-	)
-	wg.Add(len(shardIDs))
-
-	// process each shard in a separate goroutine
-	for _, shardID := range shardIDs {
+	// process each of the shards
+	for shard := range shardc {
 		go func(shardID string) {
-			defer wg.Done()
-
 			if err := c.ScanShard(ctx, shardID, fn); err != nil {
-				cancel()
-
 				select {
 				case errc <- fmt.Errorf("shard %s error: %v", shardID, err):
 					// first error to occur
+					cancel()
 				default:
 					// error has already occured
 				}
+				return
 			}
-		}(shardID)
+		}(aws.StringValue(shard.ShardId))
 	}
 
-	wg.Wait()
 	close(errc)
 
 	return <-errc
 }
 
-// ScanShard loops over records on a specific shard, calls the ScanFunc callback
-// func for each record and checkpoints the progress of scan.
+// ScanShard loops over records on a specific shard, calls the callback func
+// for each record and checkpoints the progress of scan.
 func (c *Consumer) ScanShard(ctx context.Context, shardID string, fn ScanFunc) error {
 	// get last seq number from checkpoint
 	lastSeqNum, err := c.checkpoint.Get(c.streamName, shardID)
@@ -137,7 +130,10 @@ func (c *Consumer) ScanShard(ctx context.Context, shardID string, fn ScanFunc) e
 		return fmt.Errorf("get shard iterator error: %v", err)
 	}
 
-	c.logger.Log("scanning", shardID, lastSeqNum)
+	c.logger.Log("[START]\t", shardID, lastSeqNum)
+	defer func() {
+		c.logger.Log("[STOP]\t", shardID)
+	}()
 
 	for {
 		select {
@@ -148,8 +144,7 @@ func (c *Consumer) ScanShard(ctx context.Context, shardID string, fn ScanFunc) e
 				ShardIterator: shardIterator,
 			})
 
-			// often we can recover from GetRecords error by getting a
-			// new shard iterator, else return error
+			// attempt to recover from GetRecords error by getting new shard iterator
 			if err != nil {
 				shardIterator, err = c.getShardIterator(c.streamName, shardID, lastSeqNum)
 				if err != nil {
@@ -181,6 +176,7 @@ func (c *Consumer) ScanShard(ctx context.Context, shardID string, fn ScanFunc) e
 			}
 
 			if isShardClosed(resp.NextShardIterator, shardIterator) {
+				c.logger.Log("[CLOSED]\t", shardID)
 				return nil
 			}
 
@@ -191,32 +187,6 @@ func (c *Consumer) ScanShard(ctx context.Context, shardID string, fn ScanFunc) e
 
 func isShardClosed(nextShardIterator, currentShardIterator *string) bool {
 	return nextShardIterator == nil || currentShardIterator == nextShardIterator
-}
-
-func (c *Consumer) getShardIDs(streamName string) ([]string, error) {
-	var ss []string
-	var listShardsInput = &kinesis.ListShardsInput{
-		StreamName: aws.String(streamName),
-	}
-
-	for {
-		resp, err := c.client.ListShards(listShardsInput)
-		if err != nil {
-			return nil, fmt.Errorf("ListShards error: %v", err)
-		}
-
-		for _, shard := range resp.Shards {
-			ss = append(ss, *shard.ShardId)
-		}
-
-		if resp.NextToken == nil {
-			return ss, nil
-		}
-
-		listShardsInput = &kinesis.ListShardsInput{
-			NextToken: resp.NextToken,
-		}
-	}
 }
 
 func (c *Consumer) getShardIterator(streamName, shardID, seqNum string) (*string, error) {

--- a/consumer.go
+++ b/consumer.go
@@ -87,9 +87,9 @@ func (c *Consumer) Scan(ctx context.Context, fn ScanFunc) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	go func() {
-		broker.pollShards(ctx)
+	go broker.pollShards(ctx)
 
+	go func() {
 		<-ctx.Done()
 		close(shardc)
 	}()

--- a/consumer.go
+++ b/consumer.go
@@ -81,13 +81,13 @@ func (c *Consumer) Scan(ctx context.Context, fn ScanFunc) error {
 	var (
 		errc   = make(chan error, 1)
 		shardc = make(chan *kinesis.Shard, 1)
-		broker = newBroker(c.client, c.streamName, shardc)
+		broker = newBroker(c.client, c.streamName, shardc, c.logger)
 	)
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	go broker.pollShards(ctx)
+	go broker.start(ctx)
 
 	go func() {
 		<-ctx.Done()
@@ -105,7 +105,6 @@ func (c *Consumer) Scan(ctx context.Context, fn ScanFunc) error {
 				default:
 					// error has already occured
 				}
-				return
 			}
 		}(aws.StringValue(shard.ShardId))
 	}

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -86,7 +86,7 @@ func TestScan(t *testing.T) {
 		t.Errorf("callback error expected %s, got %s", "firstDatalastData", res)
 	}
 
-	if val := ctr.counter; val != 2 {
+	if val := ctr.Get(); val != 2 {
 		t.Errorf("counter error expected %d, got %d", 2, val)
 	}
 
@@ -151,7 +151,7 @@ func TestScanShard(t *testing.T) {
 	}
 
 	// increments counter
-	if val := ctr.counter; val != 2 {
+	if val := ctr.Get(); val != 2 {
 		t.Fatalf("counter error expected %d, got %d", 2, val)
 	}
 
@@ -322,6 +322,13 @@ func (fc *fakeCheckpoint) Get(streamName, shardID string) (string, error) {
 type fakeCounter struct {
 	counter int64
 	mu      sync.Mutex
+}
+
+func (fc *fakeCounter) Get() int64 {
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+
+	return fc.counter
 }
 
 func (fc *fakeCounter) Add(streamName string, count int64) {

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -321,8 +321,12 @@ func (fc *fakeCheckpoint) Get(streamName, shardID string) (string, error) {
 // implementation of counter
 type fakeCounter struct {
 	counter int64
+	mu      sync.Mutex
 }
 
 func (fc *fakeCounter) Add(streamName string, count int64) {
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+
 	fc.counter += count
 }

--- a/examples/consumer/cp-redis/README.md
+++ b/examples/consumer/cp-redis/README.md
@@ -7,12 +7,11 @@ Read records from the Kinesis stream
 Export the required environment vars for connecting to the Kinesis stream and Redis for checkpoint:
 
 ```
-export AWS_ACCESS_KEY=
+export AWS_PROFILE=
 export AWS_REGION=
-export AWS_SECRET_KEY=
 export REDIS_URL=
 ```
 
 ### Run the consumer
 
-    $ go run main.go --app appName --stream streamName
+    $  go run main.go --app appName --stream streamName

--- a/examples/producer/README.md
+++ b/examples/producer/README.md
@@ -7,9 +7,8 @@ A prepopulated file with JSON users is available on S3 for seeing the stream.
 Export the required environment vars for connecting to the Kinesis stream:
 
 ```
-export AWS_ACCESS_KEY=
+export AWS_PROFILE=
 export AWS_REGION_NAME=
-export AWS_SECRET_KEY=
 ```
 
 ### Running the code


### PR DESCRIPTION
The addition of a shard broker will allow the consumer to be notified
when new shards are added to the stream so it can consume them.

Fixes: https://github.com/harlow/kinesis-consumer/issues/36

This still needs lots of testing but is exhibiting the desired behavior:

```
consumer-example: 2019/04/09 09:08:25 [BROKER] fetching shards
consumer-example: 2019/04/09 09:08:26 [START]	 shardId-000000000000
consumer-example: 2019/04/09 09:09:31 [CLOSED]	 shardId-000000000000
consumer-example: 2019/04/09 09:09:31 [STOP]	 shardId-000000000000
consumer-example: 2019/04/09 09:09:31 [BROKER] fetching shards
consumer-example: 2019/04/09 09:09:32 [START]	 shardId-000000000002
consumer-example: 2019/04/09 09:09:32 [START]	 shardId-000000000001
```