### PR TITLE
Allow use of existing Redis client for checkpoint store

### DIFF
--- a/store/redis/options.go
+++ b/store/redis/options.go
@@ -1,0 +1,13 @@
+package redis
+
+import redis "github.com/go-redis/redis"
+
+// Option is used to override defaults when creating a new Redis checkpoint
+type Option func(*Checkpoint)
+
+// WithClient overrides the default client
+func WithClient(client *redis.Client) Option {
+	return func(c *Checkpoint) {
+		c.client = client
+	}
+}

--- a/store/redis/redis_test.go
+++ b/store/redis/redis_test.go
@@ -2,7 +2,27 @@ package redis
 
 import (
 	"testing"
+
+	"github.com/alicebob/miniredis"
+	redis "github.com/go-redis/redis"
 )
+
+func Test_CheckpointOptions(t *testing.T) {
+	s, err := miniredis.Run()
+	if err != nil {
+		panic(err)
+	}
+	defer s.Close()
+
+	client := redis.NewClient(&redis.Options{
+		Addr: s.Addr(),
+	})
+
+	_, err = New("app", WithClient(client))
+	if err != nil {
+		t.Fatalf("new checkpoint error: %v", err)
+	}
+}
 
 func Test_CheckpointLifecycle(t *testing.T) {
 	// new


### PR DESCRIPTION
This PR allows using an existing client with the Redis checkpoint store.