### PR TITLE
Add an in-memory checkpoint to the API

### DIFF
--- a/consumer_test.go
+++ b/consumer_test.go
@@ -3,7 +3,6 @@ package consumer
 import (
 	"context"
 	"fmt"
-	"github.com/harlow/kinesis-consumer/store/memory"
 	"sync"
 	"testing"
 
@@ -12,6 +11,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/kinesis"
 	"github.com/aws/aws-sdk-go/service/kinesis/kinesisiface"
+
+	"github.com/harlow/kinesis-consumer/store/memory"
 )
 
 var records = []*kinesis.Record{
@@ -53,7 +54,7 @@ func TestScan(t *testing.T) {
 		},
 	}
 	var (
-		cp  = memory.New()
+		cp  = store.New()
 		ctr = &fakeCounter{}
 	)
 
@@ -115,7 +116,7 @@ func TestScanShard(t *testing.T) {
 	}
 
 	var (
-		cp  = memory.New()
+		cp  = store.New()
 		ctr = &fakeCounter{}
 	)
 
@@ -220,7 +221,7 @@ func TestScanShard_SkipCheckpoint(t *testing.T) {
 		},
 	}
 
-	var cp = memory.New()
+	var cp = store.New()
 
 	c, err := New("myStreamName", WithClient(client), WithStore(cp))
 	if err != nil {

--- a/store/memory/store.go
+++ b/store/memory/store.go
@@ -1,22 +1,22 @@
 // The memory store provides a store that can be used for testing and single-threaded applications.
 // DO NOT USE this in a production application where persistence beyond a single application lifecycle is necessary
 // or when there are multiple consumers.
-package memory
+package store
 
 import (
   "fmt"
   "sync"
 )
 
-func New() *Checkpoint{
-  return &Checkpoint{}
+func New() *Store {
+  return &Store{}
 }
 
-type Checkpoint struct {
+type Store struct {
   sync.Map
 }
 
-func (c *Checkpoint) SetCheckpoint(streamName, shardID, sequenceNumber string) error {
+func (c *Store) SetCheckpoint(streamName, shardID, sequenceNumber string) error {
   if sequenceNumber == "" {
     return fmt.Errorf("sequence number should not be empty")
   }
@@ -24,7 +24,7 @@ func (c *Checkpoint) SetCheckpoint(streamName, shardID, sequenceNumber string) e
   return nil
 }
 
-func (c *Checkpoint) GetCheckpoint(streamName, shardID string) (string, error) {
+func (c *Store) GetCheckpoint(streamName, shardID string) (string, error) {
   val, ok := c.Load(streamName + ":" + shardID)
   if !ok {
     return "", nil

--- a/store/memory/store.go
+++ b/store/memory/store.go
@@ -1,0 +1,33 @@
+// The memory store provides a store that can be used for testing and single-threaded applications.
+// DO NOT USE this in a production application where persistence beyond a single application lifecycle is necessary
+// or when there are multiple consumers.
+package memory
+
+import (
+  "fmt"
+  "sync"
+)
+
+func New() *Checkpoint{
+  return &Checkpoint{}
+}
+
+type Checkpoint struct {
+  sync.Map
+}
+
+func (c *Checkpoint) SetCheckpoint(streamName, shardID, sequenceNumber string) error {
+  if sequenceNumber == "" {
+    return fmt.Errorf("sequence number should not be empty")
+  }
+  c.Store(streamName+":"+shardID, sequenceNumber)
+  return nil
+}
+
+func (c *Checkpoint) GetCheckpoint(streamName, shardID string) (string, error) {
+  val, ok := c.Load(streamName + ":" + shardID)
+  if !ok {
+    return "", nil
+  }
+  return val.(string), nil
+}

--- a/store/memory/store_test.go
+++ b/store/memory/store_test.go
@@ -1,0 +1,32 @@
+package memory_test
+
+import (
+  "testing"
+
+  "github.com/harlow/kinesis-consumer/store/memory"
+)
+
+func Test_CheckpointLifecycle(t *testing.T) {
+  c := memory.New()
+
+  // set
+  c.SetCheckpoint("streamName", "shardID", "testSeqNum")
+
+  // get
+  val, err := c.GetCheckpoint("streamName", "shardID")
+  if err != nil  {
+    t.Fatalf("get checkpoint error: %v", err)
+  }
+  if val != "testSeqNum" {
+    t.Fatalf("checkpoint exists expected %s, got %s", "testSeqNum", val)
+  }
+}
+
+func Test_SetEmptySeqNum(t *testing.T) {
+  c := memory.New()
+
+  err := c.SetCheckpoint("streamName", "shardID", "")
+  if err == nil || err.Error() != "sequence number should not be empty" {
+    t.Fatalf("should not allow empty sequence number")
+  }
+}

--- a/store/memory/store_test.go
+++ b/store/memory/store_test.go
@@ -1,13 +1,11 @@
-package store_test
+package store
 
 import (
   "testing"
-
-  "github.com/harlow/kinesis-consumer/store/memory"
 )
 
 func Test_CheckpointLifecycle(t *testing.T) {
-  c := store.New()
+  c := New()
 
   // set
   c.SetCheckpoint("streamName", "shardID", "testSeqNum")
@@ -23,7 +21,7 @@ func Test_CheckpointLifecycle(t *testing.T) {
 }
 
 func Test_SetEmptySeqNum(t *testing.T) {
-  c := store.New()
+  c := New()
 
   err := c.SetCheckpoint("streamName", "shardID", "")
   if err == nil || err.Error() != "sequence number should not be empty" {

--- a/store/memory/store_test.go
+++ b/store/memory/store_test.go
@@ -1,4 +1,4 @@
-package memory_test
+package store_test
 
 import (
   "testing"
@@ -7,7 +7,7 @@ import (
 )
 
 func Test_CheckpointLifecycle(t *testing.T) {
-  c := memory.New()
+  c := store.New()
 
   // set
   c.SetCheckpoint("streamName", "shardID", "testSeqNum")
@@ -23,7 +23,7 @@ func Test_CheckpointLifecycle(t *testing.T) {
 }
 
 func Test_SetEmptySeqNum(t *testing.T) {
-  c := memory.New()
+  c := store.New()
 
   err := c.SetCheckpoint("streamName", "shardID", "")
   if err == nil || err.Error() != "sequence number should not be empty" {


### PR DESCRIPTION
Make an in-memory checkpoint part of the API to easy simple and test application development.

Fixes #101 