### PR TITLE
Add scanInterval option

### DIFF
--- a/options.go
+++ b/options.go
@@ -57,3 +57,10 @@ func WithTimestamp(t time.Time) Option {
 		c.initialTimestamp = &t
 	}
 }
+
+// WithScanInterval overrides the scan interval for the consumer
+func WithScanInterval(d time.Duration) Option {
+	return func(c *Consumer) {
+		c.scanInterval = d
+	}
+}


### PR DESCRIPTION
By default a consumer calls GetRecords as fast as it can, this can problematic because GetRecords calls are rate limited by account (https://docs.aws.amazon.com/kinesis/latest/APIReference/API_GetRecords.html)

I have encountered cases where a ProvisionedThroughputExceededException is raised in others services consuming the same stream even when no new records are sent to this stream.

This adds an option to configure how often GetRecords is called.

This changes the default behavior as GetRecords is now called every 250ms by default.

