### PR TITLE
Don't send StreamName when calling ListShards with NextToken.

### DIFF
--- a/kinesis.go
+++ b/kinesis.go
@@ -27,8 +27,7 @@ func listShards(ksis kinesisiface.KinesisAPI, streamName string) ([]*kinesis.Sha
 		}
 
 		listShardsInput = &kinesis.ListShardsInput{
-			NextToken:  resp.NextToken,
-			StreamName: aws.String(streamName),
+			NextToken: resp.NextToken,
 		}
 	}
 }


### PR DESCRIPTION
Removed the StreamName for the case when NextToken is being sent in the ListShards command.