### PR TITLE
Slice Callback Function with Batch Interval Functionality 

### DIFF
--- a/cmd/consumer/main.go
+++ b/cmd/consumer/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"log"
 	"os"
@@ -11,38 +12,47 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/kinesis"
-
 	consumer "github.com/harlow/kinesis-consumer"
-	store "github.com/harlow/kinesis-consumer/store/postgres"
 )
 
+// A myLogger provides a minimalistic logger satisfying the Logger interface.
+type myLogger struct {
+	logger *log.Logger
+}
+
+// Log logs the parameters to the stdlib logger. See log.Println.
+func (l *myLogger) Log(args ...interface{}) {
+	l.logger.Println(args...)
+}
+
 func main() {
+	var (
+		stream          = flag.String("stream", "", "Stream name")
+		kinesisEndpoint = flag.String("endpoint", "http://localhost:4567", "Kinesis endpoint")
+		awsRegion       = flag.String("region", "us-west-2", "AWS Region")
+	)
+	flag.Parse()
 
-	// postgres checkpoint
-	db, err := store.New("test", "kinesis_consumer", "host=localhost port=5432 user=postgres password= dbname=postgres sslmode=disable")
-	if err != nil {
-		log.Fatalf("new checkpoint error: %v", err)
-	}
+	// client
+	var client = kinesis.New(session.Must(session.NewSession(
+		aws.NewConfig().
+			WithEndpoint(*kinesisEndpoint).
+			WithRegion(*awsRegion),
+	)))
 
-	awsConfig := &aws.Config{
-		Region:                        aws.String("us-east-1"),
-		CredentialsChainVerboseErrors: aws.Bool(true),
-	}
-	awsConfig.Endpoint = aws.String("http://localhost:4567")
-
-	sess := session.Must(session.NewSession(awsConfig))
-	kinesisClient := kinesis.New(sess, awsConfig)
-
-	c, err := consumer.New("tally_dev_v1", consumer.WithClient(kinesisClient), consumer.WithStore(db), consumer.WithBatchSecondInterval(10))
-
+	// consumer
+	c, err := consumer.New(
+		*stream,
+		consumer.WithClient(client),
+	)
 	if err != nil {
 		log.Fatalf("consumer error: %v", err)
 	}
 
 	// scan
 	ctx := trap()
-	err = c.ScanBatch(ctx, func(r []*kinesis.Record) error {
-		fmt.Println(r)
+	err = c.Scan(ctx, func(r *consumer.Record) error {
+		fmt.Println(string(r.Data))
 		return nil // continue scanning
 	})
 	if err != nil {
@@ -58,10 +68,8 @@ func trap() context.Context {
 	go func() {
 		sig := <-sigs
 		log.Printf("received %s", sig)
-		os.Exit(0)
 		cancel()
 	}()
 
 	return ctx
-
 }

--- a/cmd/consumer/main.go
+++ b/cmd/consumer/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"log"
 	"os"
@@ -11,30 +12,39 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/kinesis"
-
 	consumer "github.com/harlow/kinesis-consumer"
-	store "github.com/harlow/kinesis-consumer/store/postgres"
 )
 
+// A myLogger provides a minimalistic logger satisfying the Logger interface.
+type myLogger struct {
+	logger *log.Logger
+}
+
+// Log logs the parameters to the stdlib logger. See log.Println.
+func (l *myLogger) Log(args ...interface{}) {
+	l.logger.Println(args...)
+}
+
 func main() {
+	var (
+		stream          = flag.String("stream", "", "Stream name")
+		kinesisEndpoint = flag.String("endpoint", "http://localhost:4567", "Kinesis endpoint")
+		awsRegion       = flag.String("region", "us-west-2", "AWS Region")
+	)
+	flag.Parse()
 
-	// postgres checkpoint
-	db, err := store.New("test", "kinesis_consumer", "host=localhost port=5432 user=postgres password= dbname=postgres sslmode=disable")
-	if err != nil {
-		log.Fatalf("new checkpoint error: %v", err)
-	}
+	// client
+	var client = kinesis.New(session.Must(session.NewSession(
+		aws.NewConfig().
+			WithEndpoint(*kinesisEndpoint).
+			WithRegion(*awsRegion),
+	)))
 
-	awsConfig := &aws.Config{
-		Region:                        aws.String("us-east-1"),
-		CredentialsChainVerboseErrors: aws.Bool(true),
-	}
-	awsConfig.Endpoint = aws.String("http://localhost:4567")
-
-	sess := session.Must(session.NewSession(awsConfig))
-	kinesisClient := kinesis.New(sess, awsConfig)
-
-	c, err := consumer.New("tally_dev_v1", consumer.WithClient(kinesisClient), consumer.WithStore(db))
-
+	// consumer
+	c, err := consumer.New(
+		*stream,
+		consumer.WithClient(client),
+	)
 	if err != nil {
 		log.Fatalf("consumer error: %v", err)
 	}
@@ -42,7 +52,7 @@ func main() {
 	// scan
 	ctx := trap()
 	err = c.Scan(ctx, func(r *consumer.Record) error {
-		fmt.Println(r)
+		fmt.Println(string(r.Data))
 		return nil // continue scanning
 	})
 	if err != nil {
@@ -58,10 +68,8 @@ func trap() context.Context {
 	go func() {
 		sig := <-sigs
 		log.Printf("received %s", sig)
-		os.Exit(0)
 		cancel()
 	}()
 
 	return ctx
-
 }

--- a/cmd/consumer/main.go
+++ b/cmd/consumer/main.go
@@ -19,7 +19,7 @@ import (
 func main() {
 
 	// postgres checkpoint
-	db, err := store.New("test", "kinesis_consumer", "host=localhost port=5432 user=postgres password= dbname=temp_db sslmode=disable")
+	db, err := store.New("test", "kinesis_consumer", "host=localhost port=5432 user=postgres password= dbname=postgres sslmode=disable")
 	if err != nil {
 		log.Fatalf("new checkpoint error: %v", err)
 	}
@@ -33,7 +33,7 @@ func main() {
 	sess := session.Must(session.NewSession(awsConfig))
 	kinesisClient := kinesis.New(sess, awsConfig)
 
-	c, err := consumer.New("tally_dev_v1", consumer.WithClient(kinesisClient), consumer.WithStore(db))
+	c, err := consumer.New("tally_dev_v1", consumer.WithClient(kinesisClient), consumer.WithStore(db), consumer.WithBatchSecondInterval(10))
 
 	if err != nil {
 		log.Fatalf("consumer error: %v", err)
@@ -58,6 +58,7 @@ func trap() context.Context {
 	go func() {
 		sig := <-sigs
 		log.Printf("received %s", sig)
+		os.Exit(0)
 		cancel()
 	}()
 

--- a/cmd/consumer/main.go
+++ b/cmd/consumer/main.go
@@ -33,7 +33,7 @@ func main() {
 	sess := session.Must(session.NewSession(awsConfig))
 	kinesisClient := kinesis.New(sess, awsConfig)
 
-	c, err := consumer.New("tally_dev_v1", consumer.WithClient(kinesisClient), consumer.WithStore(db), consumer.WithBatchSecondInterval(10))
+	c, err := consumer.New("tally_dev_v1", consumer.WithClient(kinesisClient), consumer.WithStore(db))
 
 	if err != nil {
 		log.Fatalf("consumer error: %v", err)
@@ -41,7 +41,7 @@ func main() {
 
 	// scan
 	ctx := trap()
-	err = c.Scan(ctx, func(r []*kinesis.Record) error {
+	err = c.Scan(ctx, func(r *consumer.Record) error {
 		fmt.Println(r)
 		return nil // continue scanning
 	})

--- a/cmd/consumer/main.go
+++ b/cmd/consumer/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"log"
 	"os"
@@ -12,47 +11,38 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/kinesis"
+
 	consumer "github.com/harlow/kinesis-consumer"
+	store "github.com/harlow/kinesis-consumer/store/postgres"
 )
 
-// A myLogger provides a minimalistic logger satisfying the Logger interface.
-type myLogger struct {
-	logger *log.Logger
-}
-
-// Log logs the parameters to the stdlib logger. See log.Println.
-func (l *myLogger) Log(args ...interface{}) {
-	l.logger.Println(args...)
-}
-
 func main() {
-	var (
-		stream          = flag.String("stream", "", "Stream name")
-		kinesisEndpoint = flag.String("endpoint", "http://localhost:4567", "Kinesis endpoint")
-		awsRegion       = flag.String("region", "us-west-2", "AWS Region")
-	)
-	flag.Parse()
 
-	// client
-	var client = kinesis.New(session.Must(session.NewSession(
-		aws.NewConfig().
-			WithEndpoint(*kinesisEndpoint).
-			WithRegion(*awsRegion),
-	)))
+	// postgres checkpoint
+	db, err := store.New("test", "kinesis_consumer", "host=localhost port=5432 user=postgres password= dbname=temp_db sslmode=disable")
+	if err != nil {
+		log.Fatalf("new checkpoint error: %v", err)
+	}
 
-	// consumer
-	c, err := consumer.New(
-		*stream,
-		consumer.WithClient(client),
-	)
+	awsConfig := &aws.Config{
+		Region:                        aws.String("us-east-1"),
+		CredentialsChainVerboseErrors: aws.Bool(true),
+	}
+	awsConfig.Endpoint = aws.String("http://localhost:4567")
+
+	sess := session.Must(session.NewSession(awsConfig))
+	kinesisClient := kinesis.New(sess, awsConfig)
+
+	c, err := consumer.New("tally_dev_v1", consumer.WithClient(kinesisClient), consumer.WithStore(db))
+
 	if err != nil {
 		log.Fatalf("consumer error: %v", err)
 	}
 
 	// scan
 	ctx := trap()
-	err = c.Scan(ctx, func(r *consumer.Record) error {
-		fmt.Println(string(r.Data))
+	err = c.Scan(ctx, func(r []*kinesis.Record) error {
+		fmt.Println(r)
 		return nil // continue scanning
 	})
 	if err != nil {
@@ -72,4 +62,5 @@ func trap() context.Context {
 	}()
 
 	return ctx
+
 }

--- a/options.go
+++ b/options.go
@@ -80,6 +80,7 @@ func WithAggregation(a bool) Option {
 	}
 }
 
+//WithBatchSecondInterval overrides the batch retrieval interval for the consumer
 func WithBatchSecondInterval(k int64) Option {
 	return func(c *Consumer) {
 		c.batchInterval = k

--- a/options.go
+++ b/options.go
@@ -79,3 +79,9 @@ func WithAggregation(a bool) Option {
 		c.isAggregated = a
 	}
 }
+
+func WithBatchSecondInterval(k int64) Option {
+	return func(c *Consumer) {
+		c.batchInterval = k
+	}
+}


### PR DESCRIPTION
Added additional functionality for batch interval messages with a separate callback function that returns a slice of kinesis.Record than a single reference to a consumer.Record....
* Added WithBatchSecondInterval function in Options to assign second interval for reading 
* Added ScanShardWithIntervalBatching function to send a slice of records upon a conditional evaluation of elapsed time 
* Added batchInterval data member to Consumer struct in `Consumer.go`, DEFAULT=0

To use batch interval consumption, just specify your callback function as `func([]*kinesis.Record) error` and pass it as a parameter to `ScanBatch`