### PR TITLE
Wrap underlying errors via `%w` verb

### DIFF
--- a/kinesis.go
+++ b/kinesis.go
@@ -18,7 +18,7 @@ func listShards(ksis kinesisiface.KinesisAPI, streamName string) ([]*kinesis.Sha
 	for {
 		resp, err := ksis.ListShards(listShardsInput)
 		if err != nil {
-			return nil, fmt.Errorf("ListShards error: %v", err)
+			return nil, fmt.Errorf("ListShards error: %w", err)
 		}
 		ss = append(ss, resp.Shards...)
 


### PR DESCRIPTION
As introduced in Go 1.13. This enables user of this library to check for an underlying wrapped error type via errors.Is and
errors.As functions.