### PR TITLE
Remove note about consumer groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,5 @@
 # Golang Kinesis Consumer
 
-
-__Note:__ This repo is under active development adding [Consumer Groups #42](https://github.com/harlow/kinesis-consumer/issues/42). Master should always be deployable, but there may be interface changes in master over the next few months.
-
-Latest stable release https://github.com/harlow/kinesis-consumer/releases/tag/v0.3.2
-
 ![technology Go](https://img.shields.io/badge/technology-go-blue.svg) [![Build Status](https://travis-ci.com/harlow/kinesis-consumer.svg?branch=master)](https://travis-ci.com/harlow/kinesis-consumer) [![GoDoc](https://godoc.org/github.com/harlow/kinesis-consumer?status.svg)](https://godoc.org/github.com/harlow/kinesis-consumer) [![GoReportCard](https://goreportcard.com/badge/github.com/harlow/kinesis-consumer)](https://goreportcard.com/report/harlow/kinesis-consumer)
 
 Kinesis consumer applications written in Go. This library is intended to be a lightweight wrapper around the Kinesis API to read records, save checkpoints (with swappable backends), and gracefully recover from service timeouts/errors.


### PR DESCRIPTION
Development has been paused indefinitely on consumer groups. Removing the note until this gets some traction again 