### PR TITLE
Wrap GetRecords error in ScanShard

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -192,7 +192,7 @@ func (c *Consumer) ScanShard(ctx context.Context, shardID string, fn ScanFunc) e
 			c.logger.Log("[CONSUMER] get records error:", err.Error())
 
 			if !isRetriableError(err) {
-				return fmt.Errorf("get records error: %v", err.Error())
+				return fmt.Errorf("get records error: %w", err)
 			}
 
 			shardIterator, err = c.getShardIterator(ctx, c.streamName, shardID, lastSeqNum)


### PR DESCRIPTION
Per #169, if `kinesis.GetRecords` returns an error and is not retryable, a new error is returned using`fmt.Errorf`. However, instead of using the `%w` format code which wraps the specified error, %v is used, preventing `errors.Is` tests from passing on returned errors.

### Changes
- feat: wrap returned error using %w
- test: add test assertion to verify wrapping functionality on GetRecordsError. 