### PR TITLE
Pass options to AWS SDK

### DIFF
--- a/options.go
+++ b/options.go
@@ -3,6 +3,7 @@ package consumer
 import (
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/service/kinesis"
 	"github.com/aws/aws-sdk-go-v2/service/kinesis/types"
 )
 
@@ -71,6 +72,14 @@ func WithScanInterval(d time.Duration) Option {
 func WithMaxRecords(n int64) Option {
 	return func(c *Consumer) {
 		c.maxRecords = n
+	}
+}
+
+// WithGetRecordsOptions passes the given option functions to the
+// kinesis client's GetRecords call
+func WithGetRecordsOptions(opts ...func(*kinesis.Options)) Option {
+	return func(c *Consumer) {
+		c.getRecordsOpts = opts
 	}
 }
 


### PR DESCRIPTION
I want to change some of the default AWS SDK behavior by injecting some middleware. I added a `WithGetRecordsOptions` to enable this.