### PR TITLE
fix: race condition in findNewShards

### DIFF
--- a/allgroup.go
+++ b/allgroup.go
@@ -48,7 +48,7 @@ func (g *AllGroup) Start(ctx context.Context, shardC chan types.Shard) error {
 	// necessarily close at the same time, so we could potentially get a
 	// thundering heard of notifications from the consumer.
 
-	var ticker = time.NewTicker(30 * time.Second)
+	ticker := time.NewTicker(30 * time.Second)
 
 	for {
 		if err := g.findNewShards(ctx, shardC); err != nil {
@@ -72,6 +72,8 @@ func (g *AllGroup) CloseShard(_ context.Context, shardID string) error {
 	if !ok {
 		return fmt.Errorf("closing unknown shard ID %q", shardID)
 	}
+	// Close channel and remove from map to prevent double-close
+	delete(g.shardsClosed, shardID)
 	close(c)
 	return nil
 }
@@ -95,48 +97,76 @@ func waitForCloseChannel(ctx context.Context, c <-chan struct{}) bool {
 // and uses a local cache to determine if we are already processing
 // a particular shard.
 func (g *AllGroup) findNewShards(ctx context.Context, shardC chan types.Shard) error {
-	g.shardMu.Lock()
-	defer g.shardMu.Unlock()
+	// Capture parent channels while holding the lock to avoid race conditions.
+	// We must capture all references to g.shardsClosed before releasing the lock,
+	// since concurrent calls to findNewShards() or CloseShard() may modify the map.
+	type shardWithParents struct {
+		shard          types.Shard
+		parent         <-chan struct{}
+		adjacentParent <-chan struct{}
+	}
 
-	g.logger.Log("[GROUP]", "fetching shards")
+	shardsToProcess, err := func() ([]shardWithParents, error) {
+		g.shardMu.Lock()
+		defer g.shardMu.Unlock()
 
-	shards, err := listShards(ctx, g.ksis, g.streamName)
+		g.logger.Log("[GROUP]", "fetching shards")
+
+		shards, err := listShards(ctx, g.ksis, g.streamName)
+		if err != nil {
+			g.logger.Log("[GROUP] error:", err)
+			return nil, err
+		}
+
+		// We do two `for` loops, since we have to set up all the `shardsClosed`
+		// channels before we start using any of them.  It's highly probable
+		// that Kinesis provides us the shards in dependency order (parents
+		// before children), but it doesn't appear to be a guarantee.
+		newShards := make(map[string]types.Shard)
+		for _, shard := range shards {
+			if _, ok := g.shards[*shard.ShardId]; ok {
+				continue
+			}
+			g.shards[*shard.ShardId] = shard
+			g.shardsClosed[*shard.ShardId] = make(chan struct{})
+			newShards[*shard.ShardId] = shard
+		}
+
+		result := make([]shardWithParents, 0, len(newShards))
+
+		// Only new shards need to be checked for parent dependencies
+		for _, shard := range newShards {
+			var parent, adjacentParent <-chan struct{}
+			if shard.ParentShardId != nil {
+				parent = g.shardsClosed[*shard.ParentShardId]
+			}
+			if shard.AdjacentParentShardId != nil {
+				adjacentParent = g.shardsClosed[*shard.AdjacentParentShardId]
+			}
+			result = append(result, shardWithParents{
+				shard:          shard,
+				parent:         parent,
+				adjacentParent: adjacentParent,
+			})
+		}
+
+		return result, nil
+	}()
 	if err != nil {
-		g.logger.Log("[GROUP] error:", err)
 		return err
 	}
 
-	// We do two `for` loops, since we have to set up all the `shardClosed`
-	// channels before we start using any of them.  It's highly probable
-	// that Kinesis provides us the shards in dependency order (parents
-	// before children), but it doesn't appear to be a guarantee.
-	newShards := make(map[string]types.Shard)
-	for _, shard := range shards {
-		if _, ok := g.shards[*shard.ShardId]; ok {
-			continue
-		}
-		g.shards[*shard.ShardId] = shard
-		g.shardsClosed[*shard.ShardId] = make(chan struct{})
-		newShards[*shard.ShardId] = shard
-	}
-	// only new shards need to be checked for parent dependencies
-	for _, shard := range newShards {
-		shard := shard // Shadow shard, since we use it in goroutine
-		var parent1, parent2 <-chan struct{}
-		if shard.ParentShardId != nil {
-			parent1 = g.shardsClosed[*shard.ParentShardId]
-		}
-		if shard.AdjacentParentShardId != nil {
-			parent2 = g.shardsClosed[*shard.AdjacentParentShardId]
-		}
+	// Now spawn goroutines after releasing the lock, using the captured channel references
+	for _, sp := range shardsToProcess {
+		sp := sp // Shadow variable for goroutine capture
 		go func() {
 			// Asynchronously wait for all parents of this shard to be processed
 			// before providing it out to our client.  Kinesis guarantees that a
 			// given partition key's data will be provided to clients in-order,
 			// but when splits or joins happen, we need to process all parents prior
 			// to processing children or that ordering guarantee is not maintained.
-			if waitForCloseChannel(ctx, parent1) && waitForCloseChannel(ctx, parent2) {
-				shardC <- shard
+			if waitForCloseChannel(ctx, sp.parent) && waitForCloseChannel(ctx, sp.adjacentParent) {
+				shardC <- sp.shard
 			}
 		}()
 	}

--- a/allgroup_test.go
+++ b/allgroup_test.go
@@ -1,0 +1,398 @@
+package consumer
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/kinesis"
+	"github.com/aws/aws-sdk-go-v2/service/kinesis/types"
+
+	store "github.com/harlow/kinesis-consumer/store/memory"
+)
+
+func TestAllGroup_findNewShards_RaceCondition(t *testing.T) {
+	// This test verifies that concurrent calls to findNewShards() and CloseShard()
+	// do not cause race conditions when accessing the shardsClosed map.
+	// Run with: go test -race
+
+	var callCount int
+	var mu sync.Mutex
+
+	client := &kinesisClientMock{
+		listShardsMock: func(ctx context.Context, params *kinesis.ListShardsInput, optFns ...func(*kinesis.Options)) (*kinesis.ListShardsOutput, error) {
+			mu.Lock()
+			callCount++
+			count := callCount
+			mu.Unlock()
+
+			// First call: return parent shard
+			// Second call: return parent + child shard
+			// Third+ calls: same shards
+			if count == 1 {
+				return &kinesis.ListShardsOutput{
+					Shards: []types.Shard{
+						{
+							ShardId: aws.String("shard-parent"),
+						},
+					},
+				}, nil
+			}
+			return &kinesis.ListShardsOutput{
+				Shards: []types.Shard{
+					{
+						ShardId: aws.String("shard-parent"),
+					},
+					{
+						ShardId:       aws.String("shard-child"),
+						ParentShardId: aws.String("shard-parent"),
+					},
+				},
+			}, nil
+		},
+	}
+
+	group := NewAllGroup(client, store.New(), "test-stream", &testLogger{t})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	shardC := make(chan types.Shard, 10)
+
+	// Start multiple goroutines that call findNewShards concurrently
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// Ignore errors for this test - we're checking for race conditions
+			_ = group.findNewShards(ctx, shardC)
+		}()
+	}
+
+	// Concurrently close shards to trigger map access
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			time.Sleep(10 * time.Millisecond)
+			_ = group.CloseShard(ctx, "shard-parent")
+		}()
+	}
+
+	wg.Wait()
+
+	// If we got here without a race condition, the test passes
+	t.Log("No race condition detected")
+}
+
+func TestAllGroup_findNewShards_ParentWait(t *testing.T) {
+	// Test that child shards wait for parent shards to be closed
+	client := &kinesisClientMock{
+		listShardsMock: func(ctx context.Context, params *kinesis.ListShardsInput, optFns ...func(*kinesis.Options)) (*kinesis.ListShardsOutput, error) {
+			return &kinesis.ListShardsOutput{
+				Shards: []types.Shard{
+					{
+						ShardId: aws.String("shard-parent"),
+					},
+					{
+						ShardId:       aws.String("shard-child"),
+						ParentShardId: aws.String("shard-parent"),
+					},
+				},
+			}, nil
+		},
+	}
+
+	group := NewAllGroup(client, store.New(), "test-stream", &testLogger{t})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	shardC := make(chan types.Shard, 10)
+
+	// Find new shards
+	if err := group.findNewShards(ctx, shardC); err != nil {
+		t.Fatalf("findNewShards failed: %v", err)
+	}
+
+	// Parent shard should be immediately available
+	select {
+	case shard := <-shardC:
+		if *shard.ShardId != "shard-parent" {
+			t.Errorf("expected parent shard first, got %s", *shard.ShardId)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("parent shard not received")
+	}
+
+	// Child shard should NOT be available yet (parent not closed)
+	select {
+	case shard := <-shardC:
+		t.Errorf("child shard received before parent closed: %s", *shard.ShardId)
+	case <-time.After(100 * time.Millisecond):
+		// Expected - child is waiting
+	}
+
+	// Close parent shard
+	if err := group.CloseShard(ctx, "shard-parent"); err != nil {
+		t.Fatalf("CloseShard failed: %v", err)
+	}
+
+	// Now child shard should be available
+	select {
+	case shard := <-shardC:
+		if *shard.ShardId != "shard-child" {
+			t.Errorf("expected child shard, got %s", *shard.ShardId)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("child shard not received after parent closed")
+	}
+}
+
+func TestAllGroup_findNewShards_AdjacentParents(t *testing.T) {
+	// Test that shards with two parents wait for both to close
+	client := &kinesisClientMock{
+		listShardsMock: func(ctx context.Context, params *kinesis.ListShardsInput, optFns ...func(*kinesis.Options)) (*kinesis.ListShardsOutput, error) {
+			return &kinesis.ListShardsOutput{
+				Shards: []types.Shard{
+					{
+						ShardId: aws.String("shard-parent1"),
+					},
+					{
+						ShardId: aws.String("shard-parent2"),
+					},
+					{
+						ShardId:               aws.String("shard-child"),
+						ParentShardId:         aws.String("shard-parent1"),
+						AdjacentParentShardId: aws.String("shard-parent2"),
+					},
+				},
+			}, nil
+		},
+	}
+
+	group := NewAllGroup(client, store.New(), "test-stream", &testLogger{t})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	shardC := make(chan types.Shard, 10)
+
+	// Find new shards
+	if err := group.findNewShards(ctx, shardC); err != nil {
+		t.Fatalf("findNewShards failed: %v", err)
+	}
+
+	// Both parent shards should be immediately available
+	receivedParents := make(map[string]bool)
+	for i := 0; i < 2; i++ {
+		select {
+		case shard := <-shardC:
+			receivedParents[*shard.ShardId] = true
+		case <-time.After(100 * time.Millisecond):
+			t.Fatal("parent shards not received")
+		}
+	}
+
+	if !receivedParents["shard-parent1"] || !receivedParents["shard-parent2"] {
+		t.Error("did not receive both parent shards")
+	}
+
+	// Child should NOT be available yet
+	select {
+	case shard := <-shardC:
+		t.Errorf("child shard received before both parents closed: %s", *shard.ShardId)
+	case <-time.After(100 * time.Millisecond):
+		// Expected
+	}
+
+	// Close only first parent
+	if err := group.CloseShard(ctx, "shard-parent1"); err != nil {
+		t.Fatalf("CloseShard failed: %v", err)
+	}
+
+	// Child should still NOT be available
+	select {
+	case shard := <-shardC:
+		t.Errorf("child shard received after only one parent closed: %s", *shard.ShardId)
+	case <-time.After(100 * time.Millisecond):
+		// Expected
+	}
+
+	// Close second parent
+	if err := group.CloseShard(ctx, "shard-parent2"); err != nil {
+		t.Fatalf("CloseShard failed: %v", err)
+	}
+
+	// Now child should be available
+	select {
+	case shard := <-shardC:
+		if *shard.ShardId != "shard-child" {
+			t.Errorf("expected child shard, got %s", *shard.ShardId)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("child shard not received after both parents closed")
+	}
+}
+
+func TestAllGroup_findNewShards_UnknownParent(t *testing.T) {
+	// Test that shards with unknown parents (off TRIM_HORIZON) are processed immediately
+	client := &kinesisClientMock{
+		listShardsMock: func(ctx context.Context, params *kinesis.ListShardsInput, optFns ...func(*kinesis.Options)) (*kinesis.ListShardsOutput, error) {
+			return &kinesis.ListShardsOutput{
+				Shards: []types.Shard{
+					{
+						ShardId:       aws.String("shard-child"),
+						ParentShardId: aws.String("shard-parent-unknown"),
+					},
+				},
+			}, nil
+		},
+	}
+
+	group := NewAllGroup(client, store.New(), "test-stream", &testLogger{t})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	shardC := make(chan types.Shard, 10)
+
+	// Find new shards
+	if err := group.findNewShards(ctx, shardC); err != nil {
+		t.Fatalf("findNewShards failed: %v", err)
+	}
+
+	// Child with unknown parent should be immediately available
+	select {
+	case shard := <-shardC:
+		if *shard.ShardId != "shard-child" {
+			t.Errorf("expected child shard, got %s", *shard.ShardId)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("child shard with unknown parent not received immediately")
+	}
+}
+
+func TestAllGroup_findNewShards_ContextCancellation(t *testing.T) {
+	// Test that context cancellation prevents child shards from being sent
+	client := &kinesisClientMock{
+		listShardsMock: func(ctx context.Context, params *kinesis.ListShardsInput, optFns ...func(*kinesis.Options)) (*kinesis.ListShardsOutput, error) {
+			return &kinesis.ListShardsOutput{
+				Shards: []types.Shard{
+					{
+						ShardId: aws.String("shard-parent"),
+					},
+					{
+						ShardId:       aws.String("shard-child"),
+						ParentShardId: aws.String("shard-parent"),
+					},
+				},
+			}, nil
+		},
+	}
+
+	group := NewAllGroup(client, store.New(), "test-stream", &testLogger{t})
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	shardC := make(chan types.Shard, 10)
+
+	// Find new shards
+	if err := group.findNewShards(ctx, shardC); err != nil {
+		t.Fatalf("findNewShards failed: %v", err)
+	}
+
+	// Receive parent
+	select {
+	case <-shardC:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("parent shard not received")
+	}
+
+	// Cancel context immediately (before closing parent)
+	cancel()
+
+	// Give goroutines a moment to observe cancellation
+	time.Sleep(10 * time.Millisecond)
+
+	// Now close parent with cancelled context
+	closedCtx := context.Background() // Use different context for CloseShard
+	if err := group.CloseShard(closedCtx, "shard-parent"); err != nil {
+		t.Fatalf("CloseShard failed: %v", err)
+	}
+
+	// Child should NOT be sent because the goroutine's context was cancelled
+	select {
+	case shard := <-shardC:
+		t.Errorf("child shard received after context cancellation: %s", *shard.ShardId)
+	case <-time.After(200 * time.Millisecond):
+		// Expected - goroutine observed cancellation and didn't send child
+	}
+}
+
+func TestAllGroup_CloseShard_UnknownShard(t *testing.T) {
+	client := &kinesisClientMock{
+		listShardsMock: func(ctx context.Context, params *kinesis.ListShardsInput, optFns ...func(*kinesis.Options)) (*kinesis.ListShardsOutput, error) {
+			return &kinesis.ListShardsOutput{
+				Shards: []types.Shard{},
+			}, nil
+		},
+	}
+
+	group := NewAllGroup(client, store.New(), "test-stream", &testLogger{t})
+
+	ctx := context.Background()
+
+	// Closing an unknown shard should return an error
+	err := group.CloseShard(ctx, "unknown-shard")
+	if err == nil {
+		t.Error("expected error when closing unknown shard")
+	}
+}
+
+func TestAllGroup_Start(t *testing.T) {
+	// Test the Start method which polls for new shards
+	var callCount int
+	var mu sync.Mutex
+
+	client := &kinesisClientMock{
+		listShardsMock: func(ctx context.Context, params *kinesis.ListShardsInput, optFns ...func(*kinesis.Options)) (*kinesis.ListShardsOutput, error) {
+			mu.Lock()
+			callCount++
+			mu.Unlock()
+
+			return &kinesis.ListShardsOutput{
+				Shards: []types.Shard{
+					{
+						ShardId: aws.String("shard-1"),
+					},
+				},
+			}, nil
+		},
+	}
+
+	group := NewAllGroup(client, store.New(), "test-stream", &testLogger{t})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	shardC := make(chan types.Shard, 10)
+
+	// Start should block and periodically call findNewShards
+	err := group.Start(ctx, shardC)
+	if err != nil {
+		t.Errorf("Start returned unexpected error: %v", err)
+	}
+
+	mu.Lock()
+	count := callCount
+	mu.Unlock()
+
+	// Should have been called multiple times (at least once)
+	if count < 1 {
+		t.Errorf("listShards not called during Start, count: %d", count)
+	}
+}


### PR DESCRIPTION
This PR addressed a race condition where spawned goroutines might access the `shardsClosed` map after the lock is released causing a `fatal error: concurrent map read and map write`. The solution is to capture the parent channels while still holding the lock, before spawning the goroutines.