### PR TITLE
Recover when checkpoint sequence has expired

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"strings"
 	"sync"
 	"time"
 
@@ -170,7 +171,7 @@ func (c *Consumer) ScanShard(ctx context.Context, shardID string, fn ScanFunc) e
 	}
 
 	// get shard iterator
-	shardIterator, err := c.getShardIterator(ctx, c.streamName, shardID, lastSeqNum)
+	shardIterator, lastSeqNum, err := c.getShardIteratorWithCheckpointFallback(ctx, c.streamName, shardID, lastSeqNum)
 	if err != nil {
 		return fmt.Errorf("get shard iterator error: %w", err)
 	}
@@ -197,7 +198,7 @@ func (c *Consumer) ScanShard(ctx context.Context, shardID string, fn ScanFunc) e
 				return fmt.Errorf("get records error: %w", err)
 			}
 
-			shardIterator, err = c.getShardIterator(ctx, c.streamName, shardID, lastSeqNum)
+			shardIterator, lastSeqNum, err = c.getShardIteratorWithCheckpointFallback(ctx, c.streamName, shardID, lastSeqNum)
 			if err != nil {
 				return fmt.Errorf("get shard iterator error: %w", err)
 			}
@@ -264,6 +265,24 @@ func deaggregateRecords(in []types.Record) ([]types.Record, error) {
 	return deaggregator.DeaggregateRecords(in)
 }
 
+func (c *Consumer) getShardIteratorWithCheckpointFallback(ctx context.Context, streamName, shardID, seqNum string) (*string, string, error) {
+	shardIterator, err := c.getShardIterator(ctx, streamName, shardID, seqNum)
+	if err == nil {
+		return shardIterator, seqNum, nil
+	}
+
+	if !isExpiredCheckpointSequenceError(err, seqNum) {
+		return nil, seqNum, err
+	}
+
+	c.logger.Log("[CONSUMER] checkpoint sequence is expired, falling back to TRIM_HORIZON:", shardID, seqNum)
+	shardIterator, err = c.getTrimHorizonShardIterator(ctx, streamName, shardID)
+	if err != nil {
+		return nil, seqNum, err
+	}
+	return shardIterator, "", nil
+}
+
 func (c *Consumer) getShardIterator(ctx context.Context, streamName, shardID, seqNum string) (*string, error) {
 	params := &kinesis.GetShardIteratorInput{
 		ShardId:    aws.String(shardID),
@@ -285,6 +304,34 @@ func (c *Consumer) getShardIterator(ctx context.Context, streamName, shardID, se
 		return nil, err
 	}
 	return res.ShardIterator, nil
+}
+
+func (c *Consumer) getTrimHorizonShardIterator(ctx context.Context, streamName, shardID string) (*string, error) {
+	res, err := c.client.GetShardIterator(ctx, &kinesis.GetShardIteratorInput{
+		ShardId:           aws.String(shardID),
+		StreamName:        aws.String(streamName),
+		ShardIteratorType: types.ShardIteratorTypeTrimHorizon,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.ShardIterator, nil
+}
+
+func isExpiredCheckpointSequenceError(err error, seqNum string) bool {
+	if seqNum == "" {
+		return false
+	}
+
+	oe := (*types.InvalidArgumentException)(nil)
+	if !errors.As(err, &oe) {
+		return false
+	}
+
+	// Kinesis reports expired checkpoints via InvalidArgumentException where
+	// the message references StartingSequenceNumber.
+	message := strings.ToLower(aws.ToString(oe.Message))
+	return strings.Contains(message, "startingsequencenumber") || strings.Contains(message, "starting sequence number")
 }
 
 func isRetriableError(err error) bool {

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -455,6 +456,101 @@ func TestScanShard_ShardIsClosed_WithShardClosedHandler(t *testing.T) {
 	}
 	if err.Error() != "shard closed handler error: closed shard error" {
 		t.Fatalf("unexpected error: %s", err.Error())
+	}
+}
+
+func TestScanShard_ExpiredCheckpointFallsBackToTrimHorizon(t *testing.T) {
+	var (
+		mu                       sync.Mutex
+		startingSeqCalls         int
+		trimHorizonCalls         int
+		startingSequenceObserved *string
+	)
+
+	var client = &kinesisClientMock{
+		getShardIteratorMock: func(ctx context.Context, params *kinesis.GetShardIteratorInput, optFns ...func(*kinesis.Options)) (*kinesis.GetShardIteratorOutput, error) {
+			mu.Lock()
+			defer mu.Unlock()
+
+			if params.StartingSequenceNumber != nil {
+				startingSeqCalls++
+				startingSequenceObserved = params.StartingSequenceNumber
+				return nil, &types.InvalidArgumentException{Message: aws.String("StartingSequenceNumber is no longer available")}
+			}
+
+			if params.ShardIteratorType == types.ShardIteratorTypeTrimHorizon {
+				trimHorizonCalls++
+				return &kinesis.GetShardIteratorOutput{
+					ShardIterator: aws.String("trim-horizon-iter"),
+				}, nil
+			}
+
+			t.Fatalf("unexpected get shard iterator request: %#v", params)
+			return nil, nil
+		},
+		getRecordsMock: func(ctx context.Context, params *kinesis.GetRecordsInput, optFns ...func(*kinesis.Options)) (*kinesis.GetRecordsOutput, error) {
+			if got := aws.ToString(params.ShardIterator); got != "trim-horizon-iter" {
+				t.Fatalf("expected fallback iterator %q, got %q", "trim-horizon-iter", got)
+			}
+			return &kinesis.GetRecordsOutput{
+				NextShardIterator: nil,
+				Records:           records,
+			}, nil
+		},
+	}
+
+	var cp = store.New()
+	if err := cp.SetCheckpoint("myStreamName", "myShard", "expiredSeqNum"); err != nil {
+		t.Fatalf("seed checkpoint error: %v", err)
+	}
+
+	c, err := New("myStreamName", WithClient(client), WithStore(cp), WithLogger(&testLogger{t}))
+	if err != nil {
+		t.Fatalf("new consumer error: %v", err)
+	}
+
+	if err := c.ScanShard(context.Background(), "myShard", func(r *Record) error { return nil }); err != nil {
+		t.Fatalf("scan shard error: %v", err)
+	}
+
+	if startingSeqCalls != 1 {
+		t.Fatalf("expected 1 starting-seq iterator call, got %d", startingSeqCalls)
+	}
+	if trimHorizonCalls != 1 {
+		t.Fatalf("expected 1 trim-horizon fallback call, got %d", trimHorizonCalls)
+	}
+	if aws.ToString(startingSequenceObserved) != "expiredSeqNum" {
+		t.Fatalf("expected starting sequence %q, got %q", "expiredSeqNum", aws.ToString(startingSequenceObserved))
+	}
+}
+
+func TestScanShard_InvalidArgumentWithoutExpiredSequencePatternDoesNotFallback(t *testing.T) {
+	var client = &kinesisClientMock{
+		getShardIteratorMock: func(ctx context.Context, params *kinesis.GetShardIteratorInput, optFns ...func(*kinesis.Options)) (*kinesis.GetShardIteratorOutput, error) {
+			return nil, &types.InvalidArgumentException{Message: aws.String("invalid shard id")}
+		},
+		getRecordsMock: func(ctx context.Context, params *kinesis.GetRecordsInput, optFns ...func(*kinesis.Options)) (*kinesis.GetRecordsOutput, error) {
+			t.Fatal("get records should not be called when shard iterator fails")
+			return nil, nil
+		},
+	}
+
+	var cp = store.New()
+	if err := cp.SetCheckpoint("myStreamName", "myShard", "checkpointSeqNum"); err != nil {
+		t.Fatalf("seed checkpoint error: %v", err)
+	}
+
+	c, err := New("myStreamName", WithClient(client), WithStore(cp))
+	if err != nil {
+		t.Fatalf("new consumer error: %v", err)
+	}
+
+	err = c.ScanShard(context.Background(), "myShard", func(r *Record) error { return nil })
+	if err == nil {
+		t.Fatal("expected get shard iterator error")
+	}
+	if !strings.Contains(err.Error(), "get shard iterator error") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add safe fallback when a checkpoint sequence number is no longer available in Kinesis
- only fallback for InvalidArgumentException errors that indicate an expired StartingSequenceNumber
- retry from TRIM_HORIZON and clear the in-memory checkpoint sequence to avoid repeating the bad iterator request
- add tests for fallback and non-fallback behavior

## Validation
- go test ./...
- go test -race ./...

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shard-iterator selection on a specific AWS error pattern; incorrect detection or unexpected expired checkpoints could cause rewinding to `TRIM_HORIZON` and reprocessing older records.
> 
> **Overview**
> **Improves resilience to expired checkpoints during `ScanShard`.** When `GetShardIterator` fails with an `InvalidArgumentException` indicating the `StartingSequenceNumber` is no longer available, the consumer now logs the condition, retries using a `TRIM_HORIZON` iterator, and clears the in-memory `lastSeqNum` to avoid repeating the bad request.
> 
> Adds helper functions (`getShardIteratorWithCheckpointFallback`, `getTrimHorizonShardIterator`, `isExpiredCheckpointSequenceError`) and unit tests covering both the fallback case and the non-fallback behavior for other `InvalidArgumentException` messages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f7f6a43c80f7ead9d3fcec78792ea0017aa1e3e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->