### PR TITLE
Retry checkpoint writes before exiting ScanShard

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -97,6 +97,11 @@ type ScanFunc func(*Record) error
 // as an error by any function.
 var ErrSkipCheckpoint = errors.New("skip checkpoint")
 
+const (
+	checkpointSetMaxAttempts = 3
+	checkpointSetRetryDelay  = 100 * time.Millisecond
+)
+
 // Scan launches a goroutine to process each of the shards in the stream. The ScanFunc
 // is passed through to each of the goroutines and called with each message pulled from
 // the stream.
@@ -227,7 +232,7 @@ func (c *Consumer) ScanShard(ctx context.Context, shardID string, fn ScanFunc) e
 					}
 
 					if !errors.Is(err, ErrSkipCheckpoint) {
-						if err := c.group.SetCheckpoint(c.streamName, shardID, *r.SequenceNumber); err != nil {
+						if err := c.setCheckpointWithRetry(ctx, shardID, *r.SequenceNumber); err != nil {
 							return err
 						}
 						lastSeqNum = *r.SequenceNumber
@@ -316,6 +321,29 @@ func (c *Consumer) getTrimHorizonShardIterator(ctx context.Context, streamName, 
 		return nil, err
 	}
 	return res.ShardIterator, nil
+}
+
+func (c *Consumer) setCheckpointWithRetry(ctx context.Context, shardID, sequenceNumber string) error {
+	var err error
+	for attempt := 1; attempt <= checkpointSetMaxAttempts; attempt++ {
+		err = c.group.SetCheckpoint(c.streamName, shardID, sequenceNumber)
+		if err == nil {
+			return nil
+		}
+		if attempt == checkpointSetMaxAttempts {
+			break
+		}
+
+		c.logger.Log("[CONSUMER] checkpoint set retry:", shardID, attempt, err)
+		timer := time.NewTimer(checkpointSetRetryDelay * time.Duration(attempt))
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+	return fmt.Errorf("checkpoint set error after retries: %w", err)
 }
 
 func isExpiredCheckpointSequenceError(err error, seqNum string) bool {

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -391,6 +391,106 @@ func TestScanShard_SkipCheckpointRecoveryUsesLastPersistedCheckpoint(t *testing.
 	}
 }
 
+func TestScanShard_CheckpointSetRetriesTransientFailure(t *testing.T) {
+	var (
+		mu       sync.Mutex
+		attempts int
+	)
+
+	client := &kinesisClientMock{
+		getShardIteratorMock: func(ctx context.Context, params *kinesis.GetShardIteratorInput, optFns ...func(*kinesis.Options)) (*kinesis.GetShardIteratorOutput, error) {
+			return &kinesis.GetShardIteratorOutput{ShardIterator: aws.String("iter-1")}, nil
+		},
+		getRecordsMock: func(ctx context.Context, params *kinesis.GetRecordsInput, optFns ...func(*kinesis.Options)) (*kinesis.GetRecordsOutput, error) {
+			return &kinesis.GetRecordsOutput{
+				NextShardIterator: nil,
+				Records: []types.Record{
+					{
+						Data:           []byte("record"),
+						SequenceNumber: aws.String("seq-1"),
+					},
+				},
+			}, nil
+		},
+	}
+
+	group := &groupMock{
+		getCheckpointMock: func(streamName, shardID string) (string, error) {
+			return "", nil
+		},
+		setCheckpointMock: func(streamName, shardID, sequenceNumber string) error {
+			mu.Lock()
+			defer mu.Unlock()
+			attempts++
+			if attempts < 3 {
+				return errors.New("transient checkpoint write failure")
+			}
+			return nil
+		},
+	}
+
+	c, err := New("myStreamName", WithClient(client), WithGroup(group))
+	if err != nil {
+		t.Fatalf("new consumer error: %v", err)
+	}
+
+	if err := c.ScanShard(context.Background(), "myShard", func(r *Record) error { return nil }); err != nil {
+		t.Fatalf("scan shard error: %v", err)
+	}
+
+	if attempts != 3 {
+		t.Fatalf("expected 3 checkpoint attempts, got %d", attempts)
+	}
+}
+
+func TestScanShard_CheckpointSetRetriesThenFails(t *testing.T) {
+	var attempts int
+
+	client := &kinesisClientMock{
+		getShardIteratorMock: func(ctx context.Context, params *kinesis.GetShardIteratorInput, optFns ...func(*kinesis.Options)) (*kinesis.GetShardIteratorOutput, error) {
+			return &kinesis.GetShardIteratorOutput{ShardIterator: aws.String("iter-1")}, nil
+		},
+		getRecordsMock: func(ctx context.Context, params *kinesis.GetRecordsInput, optFns ...func(*kinesis.Options)) (*kinesis.GetRecordsOutput, error) {
+			return &kinesis.GetRecordsOutput{
+				NextShardIterator: nil,
+				Records: []types.Record{
+					{
+						Data:           []byte("record"),
+						SequenceNumber: aws.String("seq-1"),
+					},
+				},
+			}, nil
+		},
+	}
+
+	rootErr := errors.New("persistent checkpoint write failure")
+	group := &groupMock{
+		getCheckpointMock: func(streamName, shardID string) (string, error) {
+			return "", nil
+		},
+		setCheckpointMock: func(streamName, shardID, sequenceNumber string) error {
+			attempts++
+			return rootErr
+		},
+	}
+
+	c, err := New("myStreamName", WithClient(client), WithGroup(group))
+	if err != nil {
+		t.Fatalf("new consumer error: %v", err)
+	}
+
+	err = c.ScanShard(context.Background(), "myShard", func(r *Record) error { return nil })
+	if err == nil {
+		t.Fatal("expected scan shard error")
+	}
+	if !errors.Is(err, rootErr) {
+		t.Fatalf("expected wrapped root error, got %v", err)
+	}
+	if attempts != 3 {
+		t.Fatalf("expected 3 checkpoint attempts, got %d", attempts)
+	}
+}
+
 func TestScanShard_ShardIsClosed(t *testing.T) {
 	var client = &kinesisClientMock{
 		getShardIteratorMock: func(ctx context.Context, params *kinesis.GetShardIteratorInput, optFns ...func(*kinesis.Options)) (*kinesis.GetShardIteratorOutput, error) {
@@ -606,6 +706,23 @@ func (c *kinesisClientMock) GetRecords(ctx context.Context, params *kinesis.GetR
 
 func (c *kinesisClientMock) GetShardIterator(ctx context.Context, params *kinesis.GetShardIteratorInput, optFns ...func(*kinesis.Options)) (*kinesis.GetShardIteratorOutput, error) {
 	return c.getShardIteratorMock(ctx, params)
+}
+
+type groupMock struct {
+	getCheckpointMock func(streamName, shardID string) (string, error)
+	setCheckpointMock func(streamName, shardID, sequenceNumber string) error
+}
+
+func (g *groupMock) Start(ctx context.Context, shardC chan types.Shard) error {
+	return nil
+}
+
+func (g *groupMock) GetCheckpoint(streamName, shardID string) (string, error) {
+	return g.getCheckpointMock(streamName, shardID)
+}
+
+func (g *groupMock) SetCheckpoint(streamName, shardID, sequenceNumber string) error {
+	return g.setCheckpointMock(streamName, shardID, sequenceNumber)
 }
 
 // implementation of counter


### PR DESCRIPTION
## Summary
- add bounded retry logic for checkpoint writes during ScanShard processing
- retry SetCheckpoint up to 3 attempts with short linear backoff before failing
- keep underlying error wrapped for errors.Is/errors.As compatibility
- add tests that first fail on current behavior:
  - transient checkpoint write failure recovers on retry
  - persistent checkpoint write failure retries then returns wrapped error

## Validation
- go test ./... -run 'TestScanShard_CheckpointSetRetriesTransientFailure|TestScanShard_CheckpointSetRetriesThenFails'
- go test ./...
- go test -race ./...

Closes #93

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes checkpoint persistence behavior during shard scanning, which can affect consumer progress/at-least-once semantics if the retry logic or context handling is wrong. Scope is limited (3 attempts with small backoff) and is covered by focused tests.
> 
> **Overview**
> **`ScanShard` now retries checkpoint persistence** instead of failing immediately when `Group.SetCheckpoint` returns an error, using a small linear backoff and respecting `ctx` cancellation.
> 
> Adds tests for both transient and persistent checkpoint write failures (including `errors.Is` wrapping behavior) and introduces a lightweight `groupMock` in `consumer_test.go` to drive these scenarios.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e8f19ee7da037046039157a36830838f0f9f2c94. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->