### PR TITLE
Handle restart with consumed parent shards

### DIFF
--- a/allgroup.go
+++ b/allgroup.go
@@ -125,6 +125,12 @@ func (g *AllGroup) findNewShards(ctx context.Context, shardC chan types.Shard) e
 			return nil, err
 		}
 
+		completedAncestors, err := g.inferCompletedAncestors(shards)
+		if err != nil {
+			g.logger.Log("[GROUP] error inferring completed ancestors:", err)
+			return nil, err
+		}
+
 		// We do two `for` loops, since we have to set up all the `shardsClosed`
 		// channels before we start using any of them.  It's highly probable
 		// that Kinesis provides us the shards in dependency order (parents
@@ -135,6 +141,11 @@ func (g *AllGroup) findNewShards(ctx context.Context, shardC chan types.Shard) e
 				continue
 			}
 			g.shards[*shard.ShardId] = shard
+			if _, ok := completedAncestors[*shard.ShardId]; ok {
+				// A checkpoint on a descendant implies this shard was already fully
+				// consumed before restart, so treat it as closed and do not re-emit it.
+				continue
+			}
 			g.shardsClosed[*shard.ShardId] = make(chan struct{})
 			newShards[*shard.ShardId] = shard
 		}
@@ -181,4 +192,53 @@ func (g *AllGroup) findNewShards(ctx context.Context, shardC chan types.Shard) e
 		}()
 	}
 	return nil
+}
+
+func (g *AllGroup) inferCompletedAncestors(shards []types.Shard) (map[string]struct{}, error) {
+	byShardID := make(map[string]types.Shard, len(shards))
+	for _, shard := range shards {
+		if shard.ShardId == nil {
+			continue
+		}
+		byShardID[*shard.ShardId] = shard
+	}
+
+	completed := make(map[string]struct{})
+	var markAncestors func(types.Shard)
+	markAncestors = func(shard types.Shard) {
+		if shard.ParentShardId != nil {
+			parentShardID := *shard.ParentShardId
+			if _, ok := completed[parentShardID]; !ok {
+				completed[parentShardID] = struct{}{}
+				if parent, exists := byShardID[parentShardID]; exists {
+					markAncestors(parent)
+				}
+			}
+		}
+		if shard.AdjacentParentShardId != nil {
+			parentShardID := *shard.AdjacentParentShardId
+			if _, ok := completed[parentShardID]; !ok {
+				completed[parentShardID] = struct{}{}
+				if parent, exists := byShardID[parentShardID]; exists {
+					markAncestors(parent)
+				}
+			}
+		}
+	}
+
+	for _, shard := range shards {
+		if shard.ShardId == nil {
+			continue
+		}
+		checkpoint, err := g.Store.GetCheckpoint(g.streamName, *shard.ShardId)
+		if err != nil {
+			return nil, err
+		}
+		if checkpoint == "" {
+			continue
+		}
+		markAncestors(shard)
+	}
+
+	return completed, nil
 }

--- a/allgroup_test.go
+++ b/allgroup_test.go
@@ -276,6 +276,116 @@ func TestAllGroup_findNewShards_UnknownParent(t *testing.T) {
 	}
 }
 
+func TestAllGroup_findNewShards_RestartWithCheckpointedChildDoesNotReemitParent(t *testing.T) {
+	client := &kinesisClientMock{
+		listShardsMock: func(ctx context.Context, params *kinesis.ListShardsInput, optFns ...func(*kinesis.Options)) (*kinesis.ListShardsOutput, error) {
+			return &kinesis.ListShardsOutput{
+				Shards: []types.Shard{
+					{
+						ShardId: aws.String("shard-parent"),
+					},
+					{
+						ShardId:       aws.String("shard-child"),
+						ParentShardId: aws.String("shard-parent"),
+					},
+				},
+			}, nil
+		},
+	}
+
+	checkpoints := store.New()
+	if err := checkpoints.SetCheckpoint("test-stream", "shard-child", "child-seq-42"); err != nil {
+		t.Fatalf("SetCheckpoint(child) failed: %v", err)
+	}
+
+	group := NewAllGroup(client, checkpoints, "test-stream", &testLogger{t})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	shardC := make(chan types.Shard, 10)
+
+	if err := group.findNewShards(ctx, shardC); err != nil {
+		t.Fatalf("findNewShards failed: %v", err)
+	}
+
+	select {
+	case shard := <-shardC:
+		if got := aws.ToString(shard.ShardId); got != "shard-child" {
+			t.Fatalf("expected restarted group to emit checkpointed child first, got %s", got)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("checkpointed child shard not received on restart")
+	}
+
+	select {
+	case shard := <-shardC:
+		t.Fatalf("unexpected extra shard emitted on restart: %s", aws.ToString(shard.ShardId))
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestAllGroup_findNewShards_RestartWithCheckpointedSiblingSkipsParent(t *testing.T) {
+	client := &kinesisClientMock{
+		listShardsMock: func(ctx context.Context, params *kinesis.ListShardsInput, optFns ...func(*kinesis.Options)) (*kinesis.ListShardsOutput, error) {
+			return &kinesis.ListShardsOutput{
+				Shards: []types.Shard{
+					{
+						ShardId: aws.String("shard-parent"),
+					},
+					{
+						ShardId:       aws.String("shard-child-a"),
+						ParentShardId: aws.String("shard-parent"),
+					},
+					{
+						ShardId:       aws.String("shard-child-b"),
+						ParentShardId: aws.String("shard-parent"),
+					},
+				},
+			}, nil
+		},
+	}
+
+	checkpoints := store.New()
+	if err := checkpoints.SetCheckpoint("test-stream", "shard-child-a", "child-a-seq-42"); err != nil {
+		t.Fatalf("SetCheckpoint(child-a) failed: %v", err)
+	}
+
+	group := NewAllGroup(client, checkpoints, "test-stream", &testLogger{t})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	shardC := make(chan types.Shard, 10)
+
+	if err := group.findNewShards(ctx, shardC); err != nil {
+		t.Fatalf("findNewShards failed: %v", err)
+	}
+
+	received := map[string]bool{}
+	for i := 0; i < 2; i++ {
+		select {
+		case shard := <-shardC:
+			received[aws.ToString(shard.ShardId)] = true
+		case <-time.After(100 * time.Millisecond):
+			t.Fatalf("expected both children on restart, received %v", received)
+		}
+	}
+
+	if !received["shard-child-a"] || !received["shard-child-b"] {
+		t.Fatalf("expected both children, received %v", received)
+	}
+	if received["shard-parent"] {
+		t.Fatalf("unexpected parent shard emitted on restart: %v", received)
+	}
+
+	select {
+	case shard := <-shardC:
+		t.Fatalf("unexpected extra shard emitted on restart: %s", aws.ToString(shard.ShardId))
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
 func TestAllGroup_findNewShards_ContextCancellation(t *testing.T) {
 	// Test that context cancellation prevents child shards from being sent
 	client := &kinesisClientMock{

--- a/group/consumergroup/group_test.go
+++ b/group/consumergroup/group_test.go
@@ -611,6 +611,43 @@ func TestGroupRunOnce_RestartSeesCompletedParentAndClaimsChild(t *testing.T) {
 	}
 }
 
+func TestGroupRunOnce_RestartSeesCompletedParentAndClaimsSiblings(t *testing.T) {
+	now := time.Unix(1700000000, 0).UTC()
+	repo := newFakeLeaseRepo([]Lease{
+		{ShardID: "parent", Completed: true},
+		{ShardID: "child-a", ParentShardID: "parent"},
+		{ShardID: "child-b", ParentShardID: "parent"},
+	})
+	client := &fakeKinesisClient{
+		shards: []types.Shard{
+			{ShardId: aws.String("parent")},
+			{ShardId: aws.String("child-a"), ParentShardId: aws.String("parent")},
+			{ShardId: aws.String("child-b"), ParentShardId: aws.String("parent")},
+		},
+	}
+
+	group, err := New(Config{
+		AppName:       "my-app",
+		StreamName:    "my-stream",
+		WorkerID:      "worker-b",
+		KinesisClient: client,
+		Repository:    repo,
+		Clock:         fakeClock{now: now},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	shardC := make(chan types.Shard, 4)
+	if err := group.runOnce(context.Background(), shardC); err != nil {
+		t.Fatalf("runOnce() error = %v", err)
+	}
+
+	if got := fmt.Sprintf("%v", drainShardIDs(shardC)); got != "[child-a child-b]" {
+		t.Fatalf("claimed shards = %s, want [child-a child-b]", got)
+	}
+}
+
 func TestGroupCloseShard_FlushesBeforeRelease(t *testing.T) {
 	now := time.Unix(1700000000, 0).UTC()
 	repo := newFakeLeaseRepo(nil)


### PR DESCRIPTION
## Summary
Avoid re-emitting already-consumed parent shards on restart in `AllGroup`.

## Changes
- infer completed ancestor shards from existing descendant checkpoints
- skip re-emitting those parents during shard discovery
- add restart regression tests for `AllGroup`
- add matching restart coverage for `group/consumergroup`

fixes https://github.com/harlow/kinesis-consumer/issues/199