### PR TITLE
Emit owned leases on restart in consumergroup runOnce

### DIFF
--- a/group/consumergroup/group.go
+++ b/group/consumergroup/group.go
@@ -301,6 +301,9 @@ func (g *Group) runOnce(ctx context.Context, shardC chan types.Shard) error {
 		if err := g.repo.RenewLeases(ctx, g.namespace(), g.workerID, plan.RenewShardIDs, now.Add(g.leaseDuration)); err != nil {
 			return err
 		}
+		for _, shardID := range plan.RenewShardIDs {
+			g.emitShardIfNeeded(shardC, shardID)
+		}
 	}
 	for _, shardID := range plan.ClaimShardIDs {
 		ok, err := g.repo.ClaimLease(ctx, g.namespace(), shardID, g.workerID, now, now.Add(g.leaseDuration))

--- a/group/consumergroup/group_test.go
+++ b/group/consumergroup/group_test.go
@@ -648,6 +648,81 @@ func TestGroupRunOnce_RestartSeesCompletedParentAndClaimsSiblings(t *testing.T) 
 	}
 }
 
+func TestGroupRunOnce_RestartEmitsAlreadyOwnedLeases(t *testing.T) {
+	now := time.Unix(1700000000, 0).UTC()
+	repo := newFakeLeaseRepo([]Lease{
+		{ShardID: "s0", Owner: "worker-a", ExpiresAt: now.Add(time.Minute)},
+		{ShardID: "s1", Owner: "worker-a", ExpiresAt: now.Add(time.Minute)},
+	})
+	client := &fakeKinesisClient{
+		shards: []types.Shard{
+			{ShardId: aws.String("s0")},
+			{ShardId: aws.String("s1")},
+		},
+	}
+
+	group, err := New(Config{
+		AppName:       "my-app",
+		StreamName:    "my-stream",
+		WorkerID:      "worker-a",
+		KinesisClient: client,
+		Repository:    repo,
+		Clock:         fakeClock{now: now},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	shardC := make(chan types.Shard, 4)
+	if err := group.runOnce(context.Background(), shardC); err != nil {
+		t.Fatalf("runOnce() error = %v", err)
+	}
+
+	if got := fmt.Sprintf("%v", drainShardIDs(shardC)); got != "[s0 s1]" {
+		t.Fatalf("emitted shards = %s, want [s0 s1]", got)
+	}
+}
+
+func TestGroupRunOnce_RestartDoesNotReemitActiveLeases(t *testing.T) {
+	now := time.Unix(1700000000, 0).UTC()
+	repo := newFakeLeaseRepo([]Lease{
+		{ShardID: "s0", Owner: "worker-a", ExpiresAt: now.Add(time.Minute)},
+	})
+	client := &fakeKinesisClient{
+		shards: []types.Shard{
+			{ShardId: aws.String("s0")},
+		},
+	}
+
+	group, err := New(Config{
+		AppName:       "my-app",
+		StreamName:    "my-stream",
+		WorkerID:      "worker-a",
+		KinesisClient: client,
+		Repository:    repo,
+		Clock:         fakeClock{now: now},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	shardC := make(chan types.Shard, 4)
+	if err := group.runOnce(context.Background(), shardC); err != nil {
+		t.Fatalf("first runOnce() error = %v", err)
+	}
+	if got := len(shardC); got != 1 {
+		t.Fatalf("first runOnce emitted %d shards, want 1", got)
+	}
+	<-shardC
+
+	if err := group.runOnce(context.Background(), shardC); err != nil {
+		t.Fatalf("second runOnce() error = %v", err)
+	}
+	if got := len(shardC); got != 0 {
+		t.Fatalf("second runOnce emitted %d shards for already-active lease, want 0", got)
+	}
+}
+
 func TestGroupCloseShard_FlushesBeforeRelease(t *testing.T) {
 	now := time.Unix(1700000000, 0).UTC()
 	repo := newFakeLeaseRepo(nil)


### PR DESCRIPTION
runOnce only emitted shards via the ClaimShardIDs path, so leases the worker already owned (RenewShardIDs path) never got scanShard goroutines started on process restart — the in-memory g.active map is fresh-empty after restart while the DDB leases are still valid, so they go through Renew, not Claim. Result: the worker heartbeats its leases indefinitely but reads nothing.

Adds the same emit call for RenewShardIDs. emitShardIfNeeded is idempotent on g.active so steady-state runs stay no-op.